### PR TITLE
Update README.md with docs badges for many repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Cauldron Stats](https://img.shields.io/badge/community-statistics-orange.svg)](https://cauldron.io/dashboards/jupyterhub)
 
 
-
+**Documentation status for several repositories**
 |JupyterHub   |Z2JH   |TLJH   | BinderHub  | repo2docker  | binder docs |
 |---|---|---|---|---|---|
 |[![Documentation Status](https://readthedocs.org/projects/jupyterhub/badge/?version=latest)](https://jupyterhub.readthedocs.org/en/latest/?badge=latest)   |[![Documentation Status](https://readthedocs.org/projects/zero-to-jupyterhub/badge/?version=latest)](https://zero-to-jupyterhub.readthedocs.org/en/latest/?badge=latest)   | [![Documentation Status](https://readthedocs.org/projects/the-littlest-jupyterhub/badge/?version=latest)](https://the-littlest-jupyterhub.readthedocs.org/en/latest/?badge=latest)  | [![Documentation Status](https://readthedocs.org/projects/binderhub/badge/?version=latest)](https://binderhub.readthedocs.org/en/latest/?badge=latest)  |  [![Documentation Status](https://readthedocs.org/projects/repo2docker/badge/?version=latest)](https://repo2docker.readthedocs.org/en/latest/?badge=latest) | [![Documentation Status](https://readthedocs.org/projects/binder/badge/?version=latest)](https://binder.readthedocs.org/en/latest/?badge=latest)  |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 
 **Documentation status for several repositories**
+
 |JupyterHub   |Z2JH   |TLJH   | BinderHub  | repo2docker  | binder docs |
 |---|---|---|---|---|---|
 |[![Documentation Status](https://readthedocs.org/projects/jupyterhub/badge/?version=latest)](https://jupyterhub.readthedocs.org/en/latest/?badge=latest)   |[![Documentation Status](https://readthedocs.org/projects/zero-to-jupyterhub/badge/?version=latest)](https://zero-to-jupyterhub.readthedocs.org/en/latest/?badge=latest)   | [![Documentation Status](https://readthedocs.org/projects/the-littlest-jupyterhub/badge/?version=latest)](https://the-littlest-jupyterhub.readthedocs.org/en/latest/?badge=latest)  | [![Documentation Status](https://readthedocs.org/projects/binderhub/badge/?version=latest)](https://binderhub.readthedocs.org/en/latest/?badge=latest)  |  [![Documentation Status](https://readthedocs.org/projects/repo2docker/badge/?version=latest)](https://repo2docker.readthedocs.org/en/latest/?badge=latest) | [![Documentation Status](https://readthedocs.org/projects/binder/badge/?version=latest)](https://binder.readthedocs.org/en/latest/?badge=latest)  |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 [![Documentation Status](http://readthedocs.org/projects/jupyterhub-team-compass/badge/?version=latest)](http://jupyterhub-team-compass.readthedocs.io/en/latest/?badge=latest)
 [![Cauldron Stats](https://img.shields.io/badge/community-statistics-orange.svg)](https://cauldron.io/dashboards/jupyterhub)
 
+
+
+|JupyterHub   |Z2JH   |TLJH   | BinderHub  | repo2docker  | binder docs |
+|---|---|---|---|---|---|
+|[![Documentation Status](https://readthedocs.org/projects/jupyterhub/badge/?version=latest)](https://jupyterhub.readthedocs.org/en/latest/?badge=latest)   |[![Documentation Status](https://readthedocs.org/projects/zero-to-jupyterhub/badge/?version=latest)](https://zero-to-jupyterhub.readthedocs.org/en/latest/?badge=latest)   | [![Documentation Status](https://readthedocs.org/projects/the-littlest-jupyterhub/badge/?version=latest)](https://the-littlest-jupyterhub.readthedocs.org/en/latest/?badge=latest)  | [![Documentation Status](https://readthedocs.org/projects/binderhub/badge/?version=latest)](https://binderhub.readthedocs.org/en/latest/?badge=latest)  |  [![Documentation Status](https://readthedocs.org/projects/repo2docker/badge/?version=latest)](https://repo2docker.readthedocs.org/en/latest/?badge=latest) | [![Documentation Status](https://readthedocs.org/projects/binder/badge/?version=latest)](https://binder.readthedocs.org/en/latest/?badge=latest)  |
+
 **Next Monthly videoconference meeting: February 8, 2018, 6pm Zurich time** [Videoconference link](https://calpoly.zoom.us/my/jupyter)
 
 ## Why have a Team Compass?


### PR DESCRIPTION
@willingc caught a bug in readthedocs yesterday that resulted in a bunch of broken docs builds. This can be difficult to spot since our documentation for each repo is on a different page. This collects the badges for several jupyterhub-related repositories in one place, so we can see if they're broken or not quickly.