### PR TITLE
Self adding to jh-maintainer list

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ as follows:
 - Chris Holdgraf (UC Berkeley, )
 - Yuvi Panda (UC Berkeley, Operational Scalability)
 - Min Ragan-Kelley (Simula, Development)
+- Erik Sundell (Sandvik CODE, Operational Scalability)
 - Carol Willing (Cal Poly, )
 
 


### PR DESCRIPTION
I wrote "Operational Scalability" like Yuvi, as I have mainly worked
on z2jh and related projects.