### PR TITLE
updating teams with emojis

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,15 @@ with the JupyterHub community. For more some more technical information
 and links to various JupyterHub repositories, see the
 `Team Compass README <https://github.com/jupyterhub/team-compass>`_.
 
+Site contents
+=============
+
+.. toctree::
+   :maxdepth: 2
+   
+   team
+   meetings
+   
 Why have a Team Compass?
 ========================
 
@@ -30,15 +39,6 @@ While we value each others individual strengths and contributions, we succeed
 or fail as a team. Whether taking corrective actions for a bug or being
 recognized for good work, the team, instead of an individual, shoulders
 the burden and success.
-
-Site contents
-=============
-
-.. toctree::
-   :maxdepth: 3
-   
-   meetings
-   team
 
 Code of Conduct
 ===============

--- a/docs/team.rst
+++ b/docs/team.rst
@@ -1,35 +1,47 @@
 .. _core_team:
 
-=========================
-The JupyterHub Core Teams
-=========================
+========================
+The JupyterHub Community
+========================
 
 There are lots of ways to contribute to the JupyterHub community.
 Code, community interaction, documentation, bug testing, bug fixes, teaching,
-proslytizing, etc...there are lots of ways to interact with the JupyterHub team!
+proslytizing, etc...we recognize any and all contributions!
 
-This page describes "core" team members of the JupyterHub community.
+This page describes "self-described core" team members of the JupyterHub community.
 These are people that spend a significant amount of their time contributing
 to the projects and community under the JupyterHub umbrella.
 
 Min Ragan-Kelley acts as the team lead for the JupyterHub organization.
 
+How can I be a part of these teams?
+-----------------------------------
+
+If you'd like to be included in any of the lists below, take the following steps:
+
+1. Fork `the team-compass repository <https://github.com/jupyterhub/team-compass>`_
+2. In one of the sections below, add yourself and (optionally) your affiliation to the list.
+3. Pick **up to four emojis** from the `Kent Dodds all contributors list <https://github.com/kentcdodds/all-contributors#emoji-key>`_ and add them after your name.
+4. Make a Pull Request to this repository!
+
 JupyterHub team
 ---------------
 
 JupyterHub is part of `Project Jupyter <http://jupyter.org/>`_ and is developed
-by an open community of contributors. JupyterHub's current maintainers are
-as follows:
+by an open community of contributors. Here is JupyterHub's current team:
 
 (listed alphabetically, with affiliation, and main areas of contribution)
 
-- Matthias Bussonnier (`@carreau <https://github.com/carreau>`_), UC Merced, Development)
-- Jessica Forde (Project Jupyter, Documentation)
-- Chris Holdgraf (UC Berkeley, Community and documentation)
-- Yuvi Panda (UC Berkeley, Operational Scalability)
-- Min Ragan-Kelley (Simula, Development)
-- Erik Sundell (Sandvik CODE, Operational Scalability)
-- Carol Willing (Cal Poly, )
+.. csv-table::
+   :header: "Name", "Link", "Organization", "Contributions"
+
+   "Matthias Bussonnier", "`@carreau <https://github.com/carreau>`_", "UC Merced", "💻🚇"
+   "Jessica Forde", "", "Project Jupyter", 📖
+   "Chris Holdgraf", "`@choldgraf <https://github.com/choldgraf>`_", "UC Berkeley", "💻🤔📖💬"
+   "Yuvi Panda", "", "UC Berkeley", "💻🚇"
+   "Min Ragan-Kelley", "", "Simula", "💻🚇"
+   "Erik Sundell", "", "Sandvik CODE", "💻🚇"
+   "Carol Willing", "", "Cal Poly", ""
 
 This team is accompanied by a much larger group of contributors to JupyterHub
 and Project Jupyter as a whole. If you would like to be listed here, please
@@ -42,13 +54,17 @@ Binder's current maintainers are as follows:
 
 (listed alphabetically, with affiliation, and main areas of contribution)
 
-- Jessica Forde (Project Jupyter, Documentation)
-- Tim Head (Wild Tree Tech)
-- Chris Holdgraf (UC Berkeley, )
-- M Pacer (UC Berkeley, )
-- Yuvi Panda (UC Berkeley, Dev & Ops)
-- Min Ragan-Kelley (Simula, Dev & Ops)
-- Carol Willing (Cal Poly, )
+
+.. csv-table::
+   :header: "Name", "Link", "Organization", "Contributions"
+
+   "Jessica Forde", "", "Project Jupyter", 📖
+   "Tim Head", "", "Wild Tree Tech", ""
+   "Chris Holdgraf", "`@choldgraf <https://github.com/choldgraf>`_", "UC Berkeley", "💻🤔📢💬"
+   "M Pacer", "", "Netflix", ""
+   "Yuvi Panda", "", "UC Berkeley", "💻🚇"
+   "Min Ragan-Kelley", "", "Simula", "💻🚇"
+   "Carol Willing", "", "Cal Poly", ""
 
 
 This team is accompanied by a much larger group of contributors to Binder,


### PR DESCRIPTION
This updates the "team" page to use an rST table and includes emojis from the kent-dodds contributions project. The goal is to make it easier for people to express their contributions to the project with a vocabulary of emojis that span many different kinds of contribution (not just code).

I took a stab at finding emojis for the things that people had already listed, but please feel free to make edits to this PR or another PR if you'd like yours updated! If you did not list any "official" role within the JupyterHub world, I didn't choose any emojis but please do add whatever you'd like!

