### PR TITLE
adding milestones to the team compass page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,8 @@ Site contents
    
    team
    meetings
-   
+   milestones
+
 Why have a Team Compass?
 ========================
 

--- a/docs/milestones.rst
+++ b/docs/milestones.rst
@@ -1,0 +1,30 @@
+=======================
+Milestones and roadmaps
+=======================
+
+A subset of JupyterHub projects organizes its releases and the
+items associated with the release using GitHub Issues and Milestones.
+
+Below are links for the upcoming milestones in several repositories. These
+are items that could use immediate help in implementation and design, and
+we'd love for you to take a shot addressing them!
+
+`BinderHub <https://github.com/jupyterhub/binderhub>`_
+======================================================
+
+* `milestones <https://github.com/jupyterhub/binderhub/milestones>`_
+
+`Zero to JupyterHub for Kubernetes <https://github.com/jupyterhub/zero-to-jupyterhub-k8s>`_
+===========================================================================================
+
+* `milestones <https://github.com/jupyterhub/zero-to-jupyterhub-k8s/milestones>`_
+
+`The Littlest JupyterHub <https://github.com/jupyterhub/the-littlest-jupyterhub>`_
+==================================================================================
+
+* `milestones <https://github.com/jupyterhub/the-littlest-jupyterhub/milestones>`_
+
+`repo2docker <https://github.com/jupyter/repo2docker>`_
+=======================================================
+
+* `milestones <https://github.com/jupyter/repo2docker/milestones>`_


### PR DESCRIPTION
This adds a link to the milestones of various JupyterHub projects to the team compass repo