### PR TITLE
adding a public page for meetings

### DIFF
--- a/docs/meetings.rst
+++ b/docs/meetings.rst
@@ -6,6 +6,12 @@ The JupyterHub team has a video meeting on the **third Thursday of every month**
 Below are links to the notes from each of these meetings over the last several
 months.
 
+**Here is a calendar of upcoming meetings**
+
+.. raw:: html
+
+   <iframe src="https://calendar.google.com/calendar/embed?src=aqpkui5q7oi32pk9tcp53hnssc%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe> 
+
 **If you'd like to join in on these meetings, please do!**
 `see the team-compass readme <https://github.com/jupyterhub/team-compass#team-meetings>`_
 for information on how to join.


### PR DESCRIPTION
adds a calendar for upcoming team meetings to the meetings page