### PR TITLE
updating roadmaps page

### DIFF
--- a/docs/milestones.rst
+++ b/docs/milestones.rst
@@ -7,10 +7,21 @@ items associated with the release using GitHub Issues, Milestones, and in some c
 These span from specific, actionable items, to more high-level goals of the project that
 still require discussion.
 
-In general, Milestones contain items that could use immediate help in implementation and design, and
-we'd love community members to take a shot at addressing them. Roadmaps tend to signal more
-abstract ideas, and often require some discussion before distilling them down into specific issues.
-We also encourage comments, questions, ideas in this process! 
+In general, **Milestones** contain items that could use immediate help in
+implementation and design, and we'd love community members to take a shot
+at addressing them. **Roadmaps** tend to signal more abstract ideas, and
+often require discussion before distilling them down into specific issues.
+
+.. note::
+
+   The JupyterHub roadmaps are run in a "yes, and" fashion. They are ideas
+   the community is excited about and would like to pursue or discuss further.
+   They are **not** meant to exclude other ideas or development (unless we
+   explicitly make a decision not to do something).
+   
+   If you have an idea you'd like to propose, please open an issue or a pull
+   request to begin discussion. Over time, the roadmap should be updated as the
+   community interests and needs evolve.
 
 Below are links for the upcoming **milestones** and **roadmaps** in several repositories. 
 

--- a/docs/milestones.rst
+++ b/docs/milestones.rst
@@ -3,28 +3,44 @@ Milestones and roadmaps
 =======================
 
 A subset of JupyterHub projects organizes its releases and the
-items associated with the release using GitHub Issues and Milestones.
+items associated with the release using GitHub Issues, Milestones, and in some cases, roadmaps.
+These span from specific, actionable items, to more high-level goals of the project that
+still require discussion.
 
-Below are links for the upcoming milestones in several repositories. These
-are items that could use immediate help in implementation and design, and
-we'd love for you to take a shot addressing them!
+In general, Milestones contain items that could use immediate help in implementation and design, and
+we'd love community members to take a shot at addressing them. Roadmaps tend to signal more
+abstract ideas, and often require some discussion before distilling them down into specific issues.
+We also encourage comments, questions, ideas in this process! 
+
+Below are links for the upcoming **milestones** and **roadmaps** in several repositories. 
+
+`jupyterhub <https://github.com/jupyter/repo2docker>`_
+=======================================================
+
+* `roadmap <https://github.com/jupyterhub/jupyterhub/blob/master/docs/source/contributing/roadmap.md>`_
+* `milestones <https://github.com/jupyterhub/jupyterhub/milestones?direction=asc&sort=due_date>`_
+
 
 `BinderHub <https://github.com/jupyterhub/binderhub>`_
 ======================================================
 
 * `milestones <https://github.com/jupyterhub/binderhub/milestones>`_
 
+
 `Zero to JupyterHub for Kubernetes <https://github.com/jupyterhub/zero-to-jupyterhub-k8s>`_
 ===========================================================================================
 
 * `milestones <https://github.com/jupyterhub/zero-to-jupyterhub-k8s/milestones>`_
+
 
 `The Littlest JupyterHub <https://github.com/jupyterhub/the-littlest-jupyterhub>`_
 ==================================================================================
 
 * `milestones <https://github.com/jupyterhub/the-littlest-jupyterhub/milestones>`_
 
+
 `repo2docker <https://github.com/jupyter/repo2docker>`_
 =======================================================
 
+* `roadmap <https://github.com/jupyter/repo2docker/blob/master/docs/source/contributing/roadmap.md>`_
 * `milestones <https://github.com/jupyter/repo2docker/milestones>`_


### PR DESCRIPTION
Updates the roadmaps page with a bit more info, and links to new roadmaps in the jupyterhub ecosystem