### PR TITLE
Moving definitive list to the team page

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -25,10 +25,35 @@ td.contrib_entry {
     text-align: center;
 }
 
+td.contrib_entry a {
+    text-decoration: none;
+}
+
 td.contrib_entry img {
     max-width: 120px;
 }
 
 table.contributors {
     margin: 0px auto;
+}
+
+/* Team colors */
+p.team {
+    font-size: .8em;
+}
+
+p.team-blue {
+    color: blue;
+}
+
+p.team-red {
+    color: red;
+}
+
+p.team-green {
+    color: green;
+}
+
+p.team-lead {
+    font-weight: bold;
 }

--- a/docs/binder_governance.rst
+++ b/docs/binder_governance.rst
@@ -1,3 +1,5 @@
+.. _binder-governance:
+
 Binder Project Governance
 =========================
 
@@ -22,6 +24,8 @@ environments in the cloud. The project also serves as the primary
 maintainer of ``mybinder.org``, a public service and demonstration of
 the BinderHub technology.
 
+.. _team-membership:
+
 Membership
 ~~~~~~~~~~
 
@@ -35,16 +39,8 @@ Currently, the Binder Project team overlaps 100% with `the BinderHub
 team`_. However, these two groups may diverge in their membership over
 time.
 
-The authoritative list of members and their roles (alphabetical sorting):
-* Tim Head (red)
-* Lindsey Heagy (blue)
-* Chris Holdgraf (red)
-* Yuvi Panda (red)
-* Min Ragan-Kelley (team leader)
-* Zach Sailer (blue)
-* Erik Sundell (blue)
-* Carol Willing (red)
-* Your Name (red or blue)
+The authoritative list of members and their roles (alphabetical sorting)
+can be found at the :ref:`binder-team` section.
 
 Team privileges
 ~~~~~~~~~~~~~~~

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -202,62 +202,6 @@ epub_copyright = copyright
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
 
-
-# -- Generate Contributors tables ------------------------------------------
-
-import pandas as pd
-import os
-from ruamel import yaml
-
-# Variables
-N_PER_ROW = 4
-
-# Init
-yaml = yaml.YAML()
-keyvals = pd.read_csv('./team/contributor_key.csv', index_col=0)
-
-template = '<td align="center" class="contrib_entry"><a href="{HANDLE_URL}"><img src="{AVATAR_URL}" class="headshot" alt="{NAME}" /><br /><p class="name"><b>{NAME}</b></p></a><p class="contrib_affiliation" >{AFFILIATION}</p><p class="contributions">{CONTRIBUTIONS}</p></td>'
-
-def _generate_contributors(contributors, keys):
-    s = ['<table class="docutils contributors">', '<tr class="row-even">']
-    for ix, person in contributors.iterrows():
-        if ix % N_PER_ROW == 0 and ix != 0:
-            s += ['</tr><tr class="row-even">']
-
-        # Build contrib text
-        this_contrib = person['contributions'].split(',')
-        contrib_text = []
-        for contrib in this_contrib:
-            if contrib in keys.index:
-                text = keyvals.loc[contrib, 'image']
-                desc = keyvals.loc[contrib, 'description']
-                contrib_text += ['<span title={TOOLTIP} class="contribs">{CONTRIB}</span>'.format(TOOLTIP=desc, CONTRIB=text)]
-            else:
-                contrib_text += ['<span class="contribs contribs_text">{CONTRIB}</span>'.format(CONTRIB=contrib)]
-
-        contrib_text = '<span class="contribs">,</span>'.join(contrib_text)
-
-        # Find user gravatar url
-        avatar_url = 'https://github.com/{HANDLE}.png?size=200'.format(HANDLE=person['handle'].lstrip('@'))
-
-        # Add user
-        s += [template.format(HANDLE=person['handle'], HANDLE_URL="https://github.com/{HANDLE}".format(HANDLE=person['handle'].lstrip('@')),
-                              AFFILIATION=person['affiliation'],
-                              AVATAR_URL=avatar_url, NAME=person['name'], CONTRIBUTIONS=contrib_text)]
-    s += ['</table>']
-    final_text = ['.. raw:: html', '']
-    for line in s:
-        final_text += ['   ' + line]
-    final_text = '\n'.join(final_text)
-    return final_text
-
-contributors_files = ['team/contributors-binder.yaml', 'team/contributors-jupyterhub.yaml']
-for ifile in contributors_files:
-    with open(ifile, 'r') as ff:
-        data = yaml.load(ff)
-    people = pd.DataFrame(data)
-    
-    table = _generate_contributors(people, keyvals)
-    new_name = os.path.splitext(ifile)[0]
-    with open(new_name+'.txt', 'w') as ff:
-        ff.write(table)
+# -- Update contributor lists --------------------------------------------
+import subprocess
+subprocess.run(['python', 'scripts/gen_contributors.py'], check=True)

--- a/docs/scripts/gen_contributors.py
+++ b/docs/scripts/gen_contributors.py
@@ -1,0 +1,71 @@
+
+"""Generate HTML Contributors tables for team pages
+"""
+import pandas as pd
+import os
+import os.path as op
+from ruamel import yaml
+
+# Variables
+N_PER_ROW = 4
+
+# Init
+path_data = op.join(op.dirname(op.abspath(__file__)), '..', 'team')
+yaml = yaml.YAML()
+keyvals = pd.read_csv(op.join(path_data, 'contributor_key.csv'), index_col=0)
+
+template_start = '<td align="center" class="contrib_entry"><a href="{HANDLE_URL}"><img src="{AVATAR_URL}" class="headshot" alt="{NAME}" /><br /><p class="name"><b>{NAME}</b></p></a><p class="contrib_affiliation">{AFFILIATION}</p>'
+template_contributions = '<p class="contributions">{CONTRIBUTIONS}</p></td>'
+templates = {'jupyterhub': template_start + template_contributions,
+             'binder': template_start + '<a href="binder_governance.html#team-roles"><p class="team team-{TEAM}">team {TEAM}</p></a>' + template_contributions}
+
+def _generate_contributors(contributors, keys, kind):
+    """Generate an HTML list of contributors, given a dataframe of their information."""
+    s = ['<table class="docutils contributors">', '<tr class="row-even">']
+    for ix, person in contributors.iterrows():
+        if ix % N_PER_ROW == 0 and ix != 0:
+            s += ['</tr><tr class="row-even">']
+
+        # Build contrib text
+        this_contrib = person['contributions'].split(',')
+        contrib_text = []
+        for contrib in this_contrib:
+            if contrib in keys.index:
+                text = keyvals.loc[contrib, 'image']
+                desc = keyvals.loc[contrib, 'description']
+                contrib_text += ['<span title={TOOLTIP} class="contribs">{CONTRIB}</span>'.format(TOOLTIP=desc, CONTRIB=text)]
+            else:
+                contrib_text += ['<span class="contribs contribs_text">{CONTRIB}</span>'.format(CONTRIB=contrib)]
+
+        contrib_text = '<span class="contribs">,</span>'.join(contrib_text)
+
+        # Find user gravatar url
+        avatar_url = 'https://github.com/{HANDLE}.png?size=200'.format(HANDLE=person['handle'].lstrip('@'))
+
+        # Add user
+        format_dict = dict(HANDLE=person['handle'], HANDLE_URL="https://github.com/{HANDLE}".format(HANDLE=person['handle'].lstrip('@')),
+                           AFFILIATION=person['affiliation'],
+                           AVATAR_URL=avatar_url, NAME=person['name'], CONTRIBUTIONS=contrib_text)
+        if kind == 'binder':
+            format_dict.update(dict(TEAM=person['team']))
+
+        # Render
+        template = templates[kind]
+        s += [template.format(**format_dict)]
+    s += ['</table>']
+    final_text = ['.. raw:: html', '']
+    for line in s:
+        final_text += ['   ' + line]
+    final_text = '\n'.join(final_text)
+    return final_text
+
+contributors_files = [op.join(path_data, 'contributors-binder.yaml'), op.join(path_data, 'contributors-jupyterhub.yaml')]
+for ifile in contributors_files:
+    with open(ifile, 'r') as ff:
+        data = yaml.load(ff)
+    people = pd.DataFrame(data)
+    kind = 'binder' if 'binder' in ifile else 'jupyterhub'
+    table = _generate_contributors(people, keyvals, kind)
+    new_name = os.path.splitext(ifile)[0]
+    with open(new_name+'.txt', 'w') as ff:
+        ff.write(table)

--- a/docs/team.rst
+++ b/docs/team.rst
@@ -8,31 +8,25 @@ There are lots of ways to contribute to the JupyterHub community.
 Code, community interaction, documentation, bug testing, bug fixes, teaching,
 proslytizing, etc...we recognize any and all contributions!
 
-This page describes "self-described core" team members of the JupyterHub community.
-These are people that spend a significant amount of their time contributing
-to the projects and community under the JupyterHub umbrella.
+This page describes "self-described core" team members of the JupyterHub
+community. These are people that spend a significant amount of their
+time contributing to the projects and community under the JupyterHub umbrella.
 
-Min Ragan-Kelley acts as the team lead for the JupyterHub organization.
+Note that these teams are accompanied by a much larger group of contributors
+to Binder, JupyterHub, and Project Jupyter as a whole.
 
-How can I be a part of these teams?
------------------------------------
+**If you'd like to be included in the teams below**:
 
-If you'd like to be included in any of the lists below, take the following steps:
+* For JupyterHub, submit a pull request to add your name and information to
+  the `JupyterHub team data <https://github.com/jupyterhub/team-compass/tree/master/docs/team/contributors-jupyterhub.yaml>`_
+  YAML file.
+* For Binder, check out the :ref:`team-membership` section of the
+  :ref:`binder-governance` document for information about how you can join the
+  Binder core team.
 
-1. Fork `the team-compass repository <https://github.com/jupyterhub/team-compass>`_
-2. Add your name and information to either the JupyterHub or the Binder team YAML files.
-   Here are some links to the latest ones:
-   
-   * `JupyterHub team data <https://github.com/jupyterhub/team-compass/tree/master/docs/team/contributors-jupyterhub.yaml>`_
-   * `BinderHub team data <https://github.com/jupyterhub/team-compass/tree/master/docs/team/contributors-binder.yaml>`_
+.. _jupyterhub-team:
 
-3. Under the ``contributions:`` section, choose four words. If you choose
-   words from the :ref:`emoji_keys` list, they'll be replaced with their emoji from
-   from the `Kent Dodds all contributors list <https://github.com/kentcdodds/all-contributors#emoji-key>`_.
-
-4. Make a Pull Request to this repository! The table will be updated the next time the docs are built.
-
-JupyterHub team
+JupyterHub Team
 ---------------
 
 JupyterHub is part of `Project Jupyter <http://jupyter.org/>`_ and is developed
@@ -40,24 +34,22 @@ by an open community of contributors. Here is JupyterHub's current team:
 
 (listed alphabetically, with affiliation, and main areas of contribution)
 
+Min Ragan-Kelley acts as the team lead for the JupyterHub organization.
+
 .. include:: team/contributors-jupyterhub.txt
 
-This team is accompanied by a much larger group of contributors to JupyterHub
-and Project Jupyter as a whole. If you would like to be listed here, please
-submit a pull request with your information.
+.. _binder-team:
 
-Binder team
+Binder Team
 -----------
 
-Binder's current maintainers are as follows:
+Binder's governance and team structure is defined in the
+:ref:`binder-governance` page. Below we list the current team members
+of Binder.
 
 (listed alphabetically, with affiliation, and main areas of contribution)
 
 .. include:: team/contributors-binder.txt
-
-This team is accompanied by a much larger group of contributors to Binder,
-JupyterHub, and Project Jupyter as a whole. If you would like to be listed
-here, please submit a pull request with your information.
 
 .. _emoji_keys:
 

--- a/docs/team/contributors-binder.yaml
+++ b/docs/team/contributors-binder.yaml
@@ -1,39 +1,62 @@
+# Use ALPHABETICAL ORDER please :-)
 - name: Jessica Forde
   handle: "@jzf2101"
   affiliation: UC Berkeley
   contributions: doc
+  team: red
 
 - name: Tim Head
   handle: "@betatim"
   affiliation: Wild Tree Tech
   contributions: ""
+  team: red
 
 - name: Lindsey Heagy
   handle: "@lheagy"
   affiliation: UC Berkeley
   contributions: ideas,example
+  team: blue
 
 - name: Chris Holdgraf
   handle: "@choldgraf"
   affiliation: Berkeley Institute for Data Science
   contributions: code,ideas,doc,question
+  team: red
 
 - name: M Pacer
   handle: "@mpacer"
   affiliation: Netflix
   contributions: ""
+  team: blue
 
 - name: Yuvi Panda
   handle: "@yuvipanda"
   affiliation: UC Berkeley
   contributions: "code,infra"
+  team: red
 
 - name: Min Ragan-Kelley
   handle: "@minrk"
   affiliation: Simula
   contributions: data,code
+  team: lead
+
+- name: Zach Sailer
+  handle: "@Zsailer"
+  affiliation: Project Jupyter
+  contributions: code,ideas,question
+  team: blue
+
+- name: Erik Sundell
+  handle: "@consideRatio"
+  affiliation: Sandvik CODE
+  contributions: code,infra
+  team: blue
 
 - name: Carol Willing
   handle: "@willingc"
   affiliation: Project Jupyter
   contributions: Python,Community
+  team: red
+
+# Green team members at the end, also alphabetical

--- a/docs/team/contributors-jupyterhub.yaml
+++ b/docs/team/contributors-jupyterhub.yaml
@@ -1,3 +1,4 @@
+# Use ALPHABETICAL ORDER please :-)
 - name: Matthias Busonnier
   handle: "@carreau"
   affiliation: UC Merced
@@ -23,6 +24,11 @@
   affiliation: Simula
   contributions: code,infra
 
+- name: Zach Sailer
+  handle: "@Zsailer"
+  affiliation: Project Jupyter
+  contributions: code,ideas,question
+
 - name: Erik Sundell
   handle: "@consideRatio"
   affiliation: Sandvik CODE
@@ -32,8 +38,3 @@
   handle: "@willingc"
   affiliation: Project Jupyter
   contributions: Python,Community
-
-- name: Zach Sailer
-  handle: "@Zsailer"
-  affiliation: Project Jupyter
-  contributions: code,ideas,question


### PR DESCRIPTION
This does the following:

* Makes the "definitive" list whatever is on the "teams" page instead of embedded in the governance doc.
* Adds the team colors to the teams page
* Factors out the teams page creation into a separate script to make it easier to maintain.

cc @betatim this was the PR I had originally made to your branch

Here's how it looks! https://68-113493831-gh.circle-artifacts.com/0/html/team.html
