### PR TITLE
updating badges and team meeting links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,14 @@ Most of the Team Compass lives in this website:
 
 ## Team information
 
-[![weekly agenda](https://img.shields.io/badge/agenda-this%20week-blue.svg)](https://hackmd.io/MYNgpgHATAZgrAIwLQAYCMwAsTNhRJAThBQGYkoATEw0gQxgkroHYg==?view)
-[![Documentation Status](http://readthedocs.org/projects/jupyterhub-team-compass/badge/?version=latest)](http://jupyterhub-team-compass.readthedocs.io/en/latest/?badge=latest)
-[![Cauldron Stats](https://img.shields.io/badge/community-statistics-orange.svg)](https://cauldron.io/dashboards/jupyterhub)
-
+[![team website](https://img.shields.io/badge/team-website-orange.svg)](https://jupyterhub-team-compass.readthedocs.io/en/latest/)
+[![monthly agenda](https://img.shields.io/badge/agenda-this%20month-blue.svg)](https://hackmd.io/u2ghJJUCRWK-zRidCFid_Q?view)
 
 **Documentation status for several repositories**
 
-|JupyterHub   |Z2JH   |TLJH   | BinderHub  | repo2docker  | binder docs |
-|:---:|:---:|:---:|:---:|:---:|:---:|
-|[![Documentation Status](https://readthedocs.org/projects/jupyterhub/badge/?version=latest)](https://jupyterhub.readthedocs.org/en/latest/?badge=latest)   |[![Documentation Status](https://readthedocs.org/projects/zero-to-jupyterhub/badge/?version=latest)](https://zero-to-jupyterhub.readthedocs.org/en/latest/?badge=latest)   | [![Documentation Status](https://readthedocs.org/projects/the-littlest-jupyterhub/badge/?version=latest)](https://the-littlest-jupyterhub.readthedocs.org/en/latest/?badge=latest)  | [![Documentation Status](https://readthedocs.org/projects/binderhub/badge/?version=latest)](https://binderhub.readthedocs.org/en/latest/?badge=latest)  |  [![Documentation Status](https://readthedocs.org/projects/repo2docker/badge/?version=latest)](https://repo2docker.readthedocs.org/en/latest/?badge=latest) | [![Documentation Status](https://readthedocs.org/projects/mybinder/badge/?version=latest)](https://mybinder.readthedocs.org/en/latest/?badge=latest)  |
+|JupyterHub   |Z2JH   |TLJH   | BinderHub  | repo2docker  | binder docs | team compass |
+|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+|[![Documentation Status](https://readthedocs.org/projects/jupyterhub/badge/?version=latest)](https://jupyterhub.readthedocs.org/en/latest/?badge=latest)   |[![Documentation Status](https://readthedocs.org/projects/zero-to-jupyterhub/badge/?version=latest)](https://zero-to-jupyterhub.readthedocs.org/en/latest/?badge=latest)   | [![Documentation Status](https://readthedocs.org/projects/the-littlest-jupyterhub/badge/?version=latest)](https://the-littlest-jupyterhub.readthedocs.org/en/latest/?badge=latest)  | [![Documentation Status](https://readthedocs.org/projects/binderhub/badge/?version=latest)](https://binderhub.readthedocs.org/en/latest/?badge=latest)  |  [![Documentation Status](https://readthedocs.org/projects/repo2docker/badge/?version=latest)](https://repo2docker.readthedocs.org/en/latest/?badge=latest) | [![Documentation Status](https://readthedocs.org/projects/mybinder/badge/?version=latest)](https://mybinder.readthedocs.org/en/latest/?badge=latest)  | [![Documentation Status](http://readthedocs.org/projects/jupyterhub-team-compass/badge/?version=latest)](http://jupyterhub-team-compass.readthedocs.io/en/latest/?badge=latest) |
 |[changelog](https://github.com/jupyterhub/jupyterhub/blob/master/docs/source/changelog.md)   |[changelog](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/CHANGELOG.md) |   |   |  |   |
 
 ---
@@ -55,6 +53,7 @@ Here are some useful links:
 
 * [**Videoconference link**](https://calpoly.zoom.us/my/jupyter) provides access to the meeting.
 * [**The monthly meeting archive**](http://jupyterhub-team-compass.readthedocs.io/en/latest/monthly-meeting/monthly_report_index.html) has the contents / summary of each meeting.
+* [**The monthly meeting agenda**](https://hackmd.io/u2ghJJUCRWK-zRidCFid_Q?view) will be filled in during the meeting.
 * [**The meeting agenda template**](https://hackmd.io/yLEoYgH8TcelS_EaXKJ6Hg?both) is used to structure the conversation each month.
 
 ### The JupyterHub and Binder core teams

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,14 @@
 Team Compass for JupyterHub and Binder
 ======================================
 
+.. image:: https://img.shields.io/badge/team-website-orange.svg
+   :target: https://jupyterhub-team-compass.readthedocs.io/en/latest/
+   :alt: team website
+
+.. image:: https://img.shields.io/badge/agenda-this%20month-blue.svg
+   :target: https://hackmd.io/u2ghJJUCRWK-zRidCFid_Q?view
+   :alt: monthly agenda
+
 This page contains links to the notes from team meetings
 with the JupyterHub community. For more some more technical information
 and links to various JupyterHub repositories, see the

--- a/docs/meetings.rst
+++ b/docs/meetings.rst
@@ -10,7 +10,7 @@ months.
 
 .. raw:: html
 
-   <iframe src="https://calendar.google.com/calendar/embed?src=aqpkui5q7oi32pk9tcp53hnssc%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe> 
+   <iframe src="https://calendar.google.com/calendar/embed?src=aqpkui5q7oi32pk9tcp53hnssc%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 
 **If you'd like to join in on these meetings, please do!**
 `see the team-compass readme <https://github.com/jupyterhub/team-compass#team-meetings>`_
@@ -28,6 +28,32 @@ reports, but below is a list of the weekly reports that we have put together.
 
 .. toctree::
    :maxdepth: 2
-   
+
    weekly-reports/weekly_report_index
 
+Updating the team meeting agenda
+================================
+
+The JupyterHub team uses HackMD to keep track of its meeting agenda before and
+during each monthly meeting. Here's the process we follow around the JupyterHub
+team meeting:
+
+1. The meeting agenda always lives `at this HackMD
+   <https://hackmd.io/u2ghJJUCRWK-zRidCFid_Q?view>`_.
+2. At the beginning of a
+   monthly cycle, copy/paste `this agenda template
+   <https://hackmd.io/yLEoYgH8TcelS_EaXKJ6Hg?both>`_ into it
+3. Before the meeting,
+   the community fills in **agenda items** they'd like to cover, as well as
+   **shoutouts** for activity in the community.
+4. Throughout the meeting, the
+   agenda is filled out with new items, notes, discussion points, and action
+   items.
+5. After the meeting, the agenda contents are copy/pasted into a new markdown
+   file in the `monthly meeting folder
+   <https://github.com/jupyterhub/team-compass/tree/master/docs/monthly-meeting>`_
+   and added to the team-compass repository in a PR
+6. The `meeting agenda HackMD <https://hackmd.io/u2ghJJUCRWK-zRidCFid_Q?view>`_
+   should then be erased and replaced
+   with a fresh `team meeting
+   template <https://hackmd.io/yLEoYgH8TcelS_EaXKJ6Hg?both>`_.


### PR DESCRIPTION
This PR does a couple things:

* Updates the badges in README to remove the cauldron stats page, and provide a link to the monthly agenda page, closes #30 
* Adds links / steps for updating the agenda, hopefully to make it easier

One thing to note: this suggests a slight difference in how we update the agenda. Instead of using a new hackmd for each monthly meeting, we cut / paste the meeting agenda text into a markdown file for our team meeting archive, then copy / paste the agenda template into the same HackMD. This way we don't have to update the link to the monthly agenda on the README / website each day, but it means we need to remember to keep re-using the same HackMD instead of creating a new one. @Zsailer and @betatim since you've been doing a lot of the work around this now/in the past, does this seem reasonable to you?