### PR TITLE
Link to march meeting video

### DIFF
--- a/docs/monthly-meeting/2019-03-21.md
+++ b/docs/monthly-meeting/2019-03-21.md
@@ -1,5 +1,7 @@
 # JupyterHub and BinderHub Team Meeting - March
 
+[Link to Meeting Recording](https://calpoly.zoom.us/recording/share/wRVITFxpH39DvUwLMLKCNZ21YwvEYmNib2HjLx_50BKwIumekTziMw)
+
 Date: 21 March 2019 at 6pm Zurich time (10am PST)
 
 **Videoconference link:** https://calpoly.zoom.us/my/jupyter


### PR DESCRIPTION
Zoom lets us share the recorded video directly from their webpage. I've added the link to the meeting's minutes. There's even a transcript of the meeting next to the call which is cool. 

This doesn't really advertise the video much. It's just a link in the meeting minutes. I'm not sure how to embed the video in the sphinx page unless it's a youtube video. Even then, I think it requires a sphinx extension...

I can look into uploading the video to the Jupyter/IPython youtube channel if we think it's worth doing. What do other's think?

