### PR TITLE
contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,7 +15,7 @@ If you'd prefer not to write code, you can help out the JupyterHub community by
 providing feedback in issues, participating in the [JupyterHub Discourse](https://discourse.jupyter.org),
 sharing your experience with JupyterHub tools in an issue, improving documentation,
 helping others with their problems, telling others about JupyterHub tools, and
-coming to weekly meetings. There are lots of others ways to contribute without writing code -
+coming to monthly meetings. There are lots of others ways to contribute without writing code -
 we are happy to have any and all contributions!
 
 If you'd like to write code, and have experience in some of the tools that JupyterHub uses

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,111 @@
+# Contributing to the JupyterHub Community
+
+JupyterHub is an open community made up of people all over the world.
+We invite participation of all forms - whether that be contributing
+code, advice, documentation, support, or just a friendly face!
+
+If you'd like to start getting involved with JupyterHub projects,
+here are a few resources to get you started.
+
+## Do I really have something to contribute to JupyterHub?
+
+Absolutely ✅. There are always ways to contribute to this community!
+
+If you have experience
+in some of the things that JupyterHub uses (e.g., shared infrastructure, dev-ops, kubernetes)
+then we would love your support in keeping these tools a useful resource for the community.
+
+If you don't have experience in these topics, then **contributing to JupyterHub is a great way to learn**.
+If you're not sure where to start, check out the **Good First Issue** button below and we'll help you
+along your journey to learning about the JupyterHub stack.
+
+## Get connected
+
+First off, get yourself connected with the JupyterHub community online. There
+are a few places where we have conversations and discussion.
+
+* [The Jupyter Community Discourse](https://discourse.jupyter.org) is a general watering hole for
+  the Jupyter community. The JupyterHub team uses this for most conversation, and tries to keep its
+  repositories focused around more actionable items.
+* [The JupyterHub team meeting](meetings.html) takes place once a month, and is open to anybody who
+  would like to attend. We try to use this as an opportunity to sync-up and connect with the community.
+* The [JupyterHub Gitter channel](https://gitter.im/jupyterhub/jupyterhub) and [Binder gitter channel](https://gitter.im/jupyterhub/binder)
+  are for in-person conversation. In general, if conversations last beyond a few seconds, we highly encourage you
+  to open a thread in the [JupyterHub Discourse page](https://discourse.jupyter.org) instead!
+
+As a reminder, we expect all members of the JupyterHub community to adhere to the
+[Jupyter Code of Conduct][link_coc] in these conversations.
+
+
+## Contributing through GitHub
+
+[git][link_git] is a really useful tool for version control.
+[GitHub][link_github] sits on top of git and supports collaborative and distributed working.
+
+You'll use [Markdown][markdown] to chat in issues and pull requests on GitHub.
+You can think of Markdown as a few little symbols around your text that will allow GitHub
+to render the text with formatting.
+For example you could write words as bold (`**bold**`), or in italics (`*italics*`),
+or as a [link][rick_roll] (`[link](https://https://youtu.be/dQw4w9WgXcQ)`) to another webpage.
+
+GitHub has a helpful page on
+[getting started with writing and formatting Markdown on GitHub][writing_formatting_github].
+
+
+## Find issues to work on
+
+If you'd like to make contributions to one of the JupyterHub repositories (this can
+be either contributing code, commenting on issues, reviewing pull requests, or improving
+documentation), we recommend checking out the **issue tags** to find issues that
+are a good place to start.
+
+The JupyterHub team tries to use tags to signal different *types* of issues. Two that you
+might be interested in are **help wanted**, and **good first issue**. [GitHub Issues Search](https://github.com/issues)
+can be used to quickly search across all of the issues in a GitHub organization that match
+one of these tags. Here are a few links below to help you get started:
+
+* [![Help Wanted](https://img.shields.io/badge/-help%20wanted-159818.svg)][link_helpwanted] *These issues contain a task that a member of the team has determined we need additional help with.*
+
+* [![Good First Issue](https://img.shields.io/badge/-good%20first%20issue-blueviolet.svg)][link_goodfirstissue] *These issues contain a task that a member of the team thinks could be a good entry point to the project.*
+
+
+## Help contributing to a specific repository
+
+Note that JupyterHub works on many different kinds of technology. The kind of tech you'll
+use (as well as the set-up and skill needed to work on that tech) will depend on the
+repository that you're working with. For example, the [Zero to JupyterHub for Kubernetes](https://github.com/jupyterhub/zero-to-jupyterhub-k8s)
+repository will touch on aspects of dev-ops and cloud infrastructure.
+
+To get oriented with a specific repository's needs and process around making new
+contributions, look for a **repository-specific contributing guide**. This often
+comes in the form of a **`CONTRIBUTING.md`** file, or a section of the documentation.
+
+For example, [here is the `CONTRIBUTING.md` file for Zero to JupyterHub](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/CONTRIBUTING.md).
+Note that it covers some of the tools you'll need for testing and developing the code,
+which are not necessarily needed for the *other* JupyterHub repositories.
+
+**Are the contributing docs unclear or misleading?** Then please let us know! We try to
+make this documentation as helpful as possible, but we often don't have the perspective of
+a new member to the community. Your input is extremely valuable in making it easy for others
+to join the JupyterHub community!
+
+
+## Thank you!
+
+You're awesome. 👋🏻😊🦄
+
+<br>
+
+*&mdash; Based on contributing guidelines from the [STEMMRoleModels][link_stemmrolemodels] project.*
+
+
+[link_helpwanted]: https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Ajupyterhub+archived%3Afalse+label%3A%22help+wanted%22+sort%3Aupdated-desc+
+[link_goodfirstissue]: https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Ajupyterhub+archived%3Afalse+label%3A%22good+first+issue%22+sort%3Aupdated-desc+
+[link_coc]: https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md
+[link_git]: https://git-scm.com
+[link_github]: https://github.com/https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md
+[link_signupinstructions]: https://help.github.com/articles/signing-up-for-a-new-github-account
+[link_stemmrolemodels]: https://github.com/KirstieJane/STEMMRoleModels
+[markdown]: https://daringfireball.net/projects/markdown
+[rick_roll]: https://www.youtube.com/watch?v=dQw4w9WgXcQ
+[writing_formatting_github]: https://help.github.com/articles/getting-started-with-writing-and-formatting-on-github

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,13 +11,25 @@ here are a few resources to get you started.
 
 Absolutely ✅. There are always ways to contribute to this community!
 
-If you have experience
-in some of the things that JupyterHub uses (e.g., shared infrastructure, dev-ops, kubernetes)
-then we would love your support in keeping these tools a useful resource for the community.
+If you'd prefer not to write code, you can help out the JupyterHub community by
+providing feedback in issues, participating in the [JupyterHub Discourse](https://discourse.jupyter.org),
+sharing your experience with JupyterHub tools in an issue, improving documentation,
+helping others with their problems, telling others about JupyterHub tools, and
+coming to weekly meetings. There are lots of others ways to contribute without writing code -
+we are happy to have any and all contributions!
+
+If you'd like to write code, and have experience in some of the tools that JupyterHub uses
+(e.g., shared infrastructure, dev-ops, kubernetes), then we would love your support in keeping
+these tools a useful resource for the community. Try finding the
+[![Help Wanted](https://img.shields.io/badge/-help%20wanted-159818.svg)][link_helpwanted] tag
+in a repository and please ping a JupyterHub team member if you'd like any assistance!
 
 If you don't have experience in these topics, then **contributing to JupyterHub is a great way to learn**.
-If you're not sure where to start, check out the **Good First Issue** button below and we'll help you
-along your journey to learning about the JupyterHub stack.
+The JupyterHub community works hard to share its knowledge of both JupyterHub tools and the
+general problems that they try to solve, and we'd be happy to help you out.
+If you're not sure where to start, look for the [![Good First Issue](https://img.shields.io/badge/-good%20first%20issue-blueviolet.svg)][link_goodfirstissue]
+tag to begin your journey  learning about the JupyterHub stack.
+
 
 ## Get connected
 
@@ -46,7 +58,7 @@ You'll use [Markdown][markdown] to chat in issues and pull requests on GitHub.
 You can think of Markdown as a few little symbols around your text that will allow GitHub
 to render the text with formatting.
 For example you could write words as bold (`**bold**`), or in italics (`*italics*`),
-or as a [link][rick_roll] (`[link](https://https://youtu.be/dQw4w9WgXcQ)`) to another webpage.
+or as a [link][rick_roll] (`[link](https://youtu.be/dQw4w9WgXcQ)`) to another webpage.
 
 GitHub has a helpful page on
 [getting started with writing and formatting Markdown on GitHub][writing_formatting_github].

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Site contents
    :maxdepth: 2
 
    team
+   contributing
    meetings
    milestones
    binder_governance

--- a/docs/meetings.rst
+++ b/docs/meetings.rst
@@ -1,6 +1,8 @@
-====================
-Team meeting reports
-====================
+.. _team-meetings:
+
+==================================
+Team meetings and meetings reports
+==================================
 
 The JupyterHub team has a video meeting on the **third Thursday of every month**.
 Below are links to the notes from each of these meetings over the last several


### PR DESCRIPTION
We've got a few contributing guides in specific repositories, but I couldn't find a "meta" contributing guide that helps point people in the right direction. I was inspired by [@emdupre's version](https://github.com/jupyter/jupyter-book/blob/master/CONTRIBUTING.md) of @kirstiejane's STEMMRoleModels contributing guide, and put something like this together for the team compass repository.

Would love feedback if folks have ideas!

Note that this also overlaps with some of the content in the [original jupyter contributing guide](https://jupyter.readthedocs.io/en/latest/contributor/content-contributor.html). If that's a better place for this, perhaps we can work to update it there as well? (maybe @willingc has thoughts on that?)