### PR TITLE
Adding Sarah to the blue team

### DIFF
--- a/docs/team/contributors-binder.yaml
+++ b/docs/team/contributors-binder.yaml
@@ -4,6 +4,12 @@
   affiliation: UC Berkeley
   contributions: doc
   team: red
+  
+- name: Sarah Gibson
+  handle: "@sgibson91"
+  affiliation: [The Turing Institute](https://www.turing.ac.uk/)
+  contributions: ""
+  team: blue
 
 - name: Tim Head
   handle: "@betatim"

--- a/docs/team/contributors-binder.yaml
+++ b/docs/team/contributors-binder.yaml
@@ -7,7 +7,7 @@
   
 - name: Sarah Gibson
   handle: "@sgibson91"
-  affiliation: [The Turing Institute](https://www.turing.ac.uk/)
+  affiliation: The Turing Institute
   contributions: ""
   team: blue
 

--- a/docs/team/contributors-binder.yaml
+++ b/docs/team/contributors-binder.yaml
@@ -8,7 +8,7 @@
 - name: Sarah Gibson
   handle: "@sgibson91"
   affiliation: The Alan Turing Institute
-  contributions: ""
+  contributions: question,doc,tutorial
   team: blue
 
 - name: Tim Head

--- a/docs/team/contributors-binder.yaml
+++ b/docs/team/contributors-binder.yaml
@@ -7,7 +7,7 @@
   
 - name: Sarah Gibson
   handle: "@sgibson91"
-  affiliation: The Turing Institute
+  affiliation: The Alan Turing Institute
   contributions: ""
   team: blue
 


### PR DESCRIPTION
Hey all - over the last few months, @sgibson91 has been helping out teaching others, opening issues/PRs, and being active in the Gitter channel and on team meetings. She's maintaining the BinderHub at the Turing Institute and has been growing the Binder community in her neck of the woods.

This PR adds Sarah G. to the blue team! I think she'd be a great addition!

Here's what the page will looks like: https://113-113493831-gh.circle-artifacts.com/0/html/team.html#binder-team

(note that I haven't added in the "what you help out with" part of the data because I didn't want to make assumptions for Sarah, but if you'd like to update this yourself, feel free to do so either as a suggested change to this PR, or as a follow-up PR!)

also pinging the @jupyterhub/binder-team so they have a chance to take a look at this