### PR TITLE
adding onboarding docs

### DIFF
--- a/docs/binder/governance.rst
+++ b/docs/binder/governance.rst
@@ -64,12 +64,12 @@ organizational connections, welcoming new contributors, diversifying
 the team, growing the community, creating an open project culture, evangelizing
 and helping others deploy BinderHub. They should be receptive to
 comments and ideas on the GitHub issues, in the Binder gitter channel, and
-on the [discourse forum](http://discourse.jupyter.org/).
+on the `discourse forum <http://discourse.jupyter.org/>`_.
 They should strive to make project decisions that reflect these
 community opinions.
 
 Team members are expected to keep themselves informed about issues and PRs on
-the [team-compass repository](https://github.com/jupyterhub/team-compass). We
+the `team-compass repository <https://github.com/jupyterhub/team-compass>`_. We
 use this repository for important discussions and decision making, sometimes
 with a timeframe of ~48h. One way to keep yourself informed is to "watch"
 (button in the top right corner of the GitHub UI). You are free to use other

--- a/docs/binder/governance.rst
+++ b/docs/binder/governance.rst
@@ -50,6 +50,8 @@ Team privileges
 -  merge privileges on the project repositories
 -  red members can nominate other individuals to team membership
 
+.. _binder-team-responsibilities:
+
 Team responsibilities
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Site contents
    meetings
    milestones
    team/adding-members
+   team/member-guide
    binder/governance
    binder/subdomains
    tools

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,7 @@ Site contents
    contributing
    meetings
    milestones
+   team/adding-members
    binder/governance
    binder/subdomains
    tools

--- a/docs/team/adding-members.rst
+++ b/docs/team/adding-members.rst
@@ -10,7 +10,7 @@ Adding a new team member
 
 For someone to become a team member, they should already be a consistent,
 positive, productive member of the community. Newcomers are encouraged to
-become team members, but after they've shown a sustained interest in
+become team members, after they've shown a sustained interest in
 engaging with the community. Moreover, team members should be interested in
 **continuing their engagement** over a long-ish period of time, generally
 putting in more time and effort than non-team members. This doesn't have to

--- a/docs/team/adding-members.rst
+++ b/docs/team/adding-members.rst
@@ -1,0 +1,75 @@
+======================================
+Adding and onboarding new team members
+======================================
+
+This page contains information about adding new team members and onboarding
+them.
+
+Adding a new team members
+=========================
+
+For someone to become a team member, they should already be a consistent,
+positive, productive member of the community. Newcomers are encouraged to
+become team members, but after they've shown a sustained interest in
+engaging with the community. Moreover, team members should be interested in
+**continuing their engagement** over a long-ish period of time, generally
+putting in more time and effort than non-team members. This doesn't have to
+mean contributing code - it can be assisting others in forums/issues, reviewing
+pull requests, participating in team meetings, etc.
+
+Any new team members must be "championed" by a pre-existing team member. This
+is a person who recommends that the new person be invited to join the team.
+This process takes the following steps:
+
+1. The champion should first discuss internally with team members to get buy-
+   in and ensure that there's general consensus before officially starting
+   the process.
+2. If there seems to be team consensus,
+   the champion contacts the potential new team member and ask if they are
+   interested. Don't forget to run them by the :ref:`binder-team-responsibilities`
+   page to make sure they understand what they're signing up for.
+   If so, then move to the next step.
+3. The champion opens a new issue in the `team compass repository <https://github.com/jupyterhub/team-compass>`_.
+   The issue should state your support of the new team member, discuss why
+   you think they are great and why they should join the team.
+4. This issue should stay open for around 10 days to give members of the team
+   a chance to weigh in their thoughts (and support!).
+5. If there are no objections that haven't been resolved, the new team member
+   is welcomed into the community as an official team member!
+6. Finally, make sure to follow the steps in :ref:`onboarding`.
+
+
+.. _onboarding:
+
+Onboarding a new team member
+============================
+
+Once a new team member has joined, there are a number of things to take care
+of in order to make sure they're in a position to be a productive and happy
+member of the team. Copy and paste the checklist below into a new GitHub
+issue and follow each step. Once all steps are completed, we can close the
+issue and the team member is now ready to go!
+
+.. code-block:: markdown
+
+   **Membership**
+
+   - [ ] Add them to the [binderhub google group](https://groups.google.com/forum/#!forum/binderhub-dev)
+   - [ ] Add them to the [binderhub team in the github organization](https://github.com/orgs/jupyterhub/teams/binder-team)
+   
+   **Permissions**
+
+   - [ ] Make sure they have permissions on the [google cloud projects](https://console.cloud.google.com/home/dashboard?project=binder-prod)
+         (binder-prod, binder-staging, binder-sandbox)
+   - [ ] Add them as collaborators on the repo2docker and BinderHub PyPI packages
+   - [ ] Add them to the [jupyterhub team google drive](https://drive.google.com/drive/folders/0B8VZ4vaOYWZ3a2dyeEp6NzBKbnM?usp=sharing)
+   
+   **Learning**
+
+   - [ ] provide an overview of areas where they can contribute? (e.g. docs, discourse / twitter, tackling issues, ...) 
+   - [ ] overview of pr process? (e.g. when is it appropriate to merge a pr that you have reviewed? or what to expect when a pr of yours is being reviewed)
+   
+   **Community**
+
+   - [ ] Add them to the [jupyterhub or binderhub team yaml files](https://github.com/jupyterhub/team-compass/tree/5d014f3af161e3abcf79c7adfb77620607929d77/docs/team)
+   - [ ] Tell people in Discourse + Twitter about our awesome new community member

--- a/docs/team/adding-members.rst
+++ b/docs/team/adding-members.rst
@@ -46,30 +46,63 @@ Onboarding a new team member
 
 Once a new team member has joined, there are a number of things to take care
 of in order to make sure they're in a position to be a productive and happy
-member of the team. Copy and paste the checklist below into a new GitHub
+member of the team. These sections cover what to do!
+
+The onboarding checklist
+------------------------
+
+Copy and paste the checklist below into a new GitHub
 issue and follow each step. Once all steps are completed, we can close the
 issue and the team member is now ready to go!
 
-.. code-block:: markdown
-
+.. code-block:: md
+   
+   **Things the new team member needs**
+   - [ ] A gmail account (for GKE credentials + Google team drive)
+   - [ ] A [PyPI account](https://pypi.org) (for PyPI access)
+   - [ ] A [Discourse account](https://discourse.jupyter.org)
+   
    **Membership**
-
+   
    - [ ] Add them to the [binderhub google group](https://groups.google.com/forum/#!forum/binderhub-dev)
    - [ ] Add them to the [binderhub team in the github organization](https://github.com/orgs/jupyterhub/teams/binder-team)
+   - [ ] Add them to the [Discourse jupyterhub group](https://discourse.jupyter.org/g/jupyterhub-team)
    
    **Permissions**
-
+   
    - [ ] Make sure they have permissions on the [google cloud projects](https://console.cloud.google.com/home/dashboard?project=binder-prod)
          (binder-prod, binder-staging, binder-sandbox)
    - [ ] Add them as collaborators on the repo2docker and BinderHub PyPI packages
    - [ ] Add them to the [jupyterhub team google drive](https://drive.google.com/drive/folders/0B8VZ4vaOYWZ3a2dyeEp6NzBKbnM?usp=sharing)
    
    **Learning**
-
-   - [ ] provide an overview of areas where they can contribute? (e.g. docs, discourse / twitter, tackling issues, ...) 
-   - [ ] overview of pr process? (e.g. when is it appropriate to merge a pr that you have reviewed? or what to expect when a pr of yours is being reviewed)
+   
+   - [ ] Send them [a short onboarding message](https://jupyterhub-team-compass.readthedocs.io/team/adding-members.html#an-official-onboarding-message)
    
    **Community**
-
+   
    - [ ] Add them to the [jupyterhub or binderhub team yaml files](https://github.com/jupyterhub/team-compass/tree/5d014f3af161e3abcf79c7adfb77620607929d77/docs/team)
    - [ ] Tell people in Discourse + Twitter about our awesome new community member
+
+An official onboarding message
+------------------------------
+
+The last thing to do after all of the boxes have been checked is to send the
+person a message saying "welcome to the team!" This has two goals: one is
+to give a friendly welcome to our new member and make it "official", the other
+is to provide them some guidance and helpful information to get started. Here
+is a template message to send. It checks off all of the boxes in the
+"learning" section above.
+
+.. code-block:: md
+
+   Hello <name>, and welcome to the JupyterHub team! 🎉🎉🎉
+   
+   We are really excited for you to join the community. To help you get started,
+   check out the [jupyterhub team member guide](https://jupyterhub-team-compass.readthedocs.io/team/member-guide.html)
+   as well as the [BinderHub team responsibilities](https://jupyterhub-team-compass.readthedocs.io/en/latest/binder/governance.html#team-responsibilities)
+   page.
+
+   If you've got any questions or would just like to chat, don't hesitate to
+   reach out to folks on the Gitter channels or on Discourse!
+   

--- a/docs/team/adding-members.rst
+++ b/docs/team/adding-members.rst
@@ -5,7 +5,7 @@ Adding and onboarding new team members
 This page contains information about adding new team members and onboarding
 them.
 
-Adding a new team members
+Adding a new team member
 =========================
 
 For someone to become a team member, they should already be a consistent,

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -44,7 +44,7 @@ documentation, code, etc are always welcome, along with anything in the
 guide in the team-compass.
    
 Don't forget that, as a member of the team, you're representing the community
-when you interact with people online. Try to keep a friendly, positive
+when you interact with people (online and offline). Try to keep a friendly, positive
 attitude, and be welcoming and helpful in bringing others into the community
 and answering their questions.
    

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -1,0 +1,96 @@
+# JupyterHub team guide
+      
+This page holds resources for members of the JupyterHub and Binder teams.
+They're meant to guide team members to be happy, productive members of the
+team!
+
+## What are the team resources?
+   
+There are a few resources that are particularly useful for team members. Here's
+a quick list to get you started.
+   
+* [**The JupyterHub Team Compass**](https://jupyterhub-team-compass.readthedocs.io/en/latest/contributing.html)
+  is a repository with lots of information about team-related things. It has
+  development tips, information about team meetings, milestones and roadmaps,
+  etc.
+* [**The JupyterHub Team Compass issues**](https://github.com/jupyterhub/team-compass/issues)
+  are where we often discuss specific, actionable things related to the *team*
+  (e.g., discussing whether to change something in the team-compass repo).
+* [**The JupyterHub internal Discourse category**](https://discourse.jupyter.org/c/jupyterhub/internal)
+  is a place to have more general conversations between team members. It's only
+  viewable by members of the [JupyterHub Team Discourse Group](https://discourse.jupyter.org/g/jupyterhub-team).
+* **The JupyterHub gitter channels** are used to have synchronous conversation
+  for several projects. If a conversation will likely span multiple hours,
+  or is relevant to many people, consider opening a thread in Discourse or
+  the `team-compass` repository instead. Here are the relevant Gitters:
+
+    * [The JupyterHub Gitter](https://gitter.im/jupyterhub/jupyterhub) is for
+      discussing JupyterHub, Z2JH, TLJH, etc.
+    * [The Binder Gitter](https://gitter.im/jupyterhub/binder) is for
+      discussion with Binder users about how to use Binder.
+    * [The mybinder.org-deploy gitter](https://gitter.im/jupyterhub/mybinder.org-deploy)
+      is for discussion around **operating myinder.org**.
+
+* [**The mybinder SRE guide**](https://mybinder-sre.readthedocs.io/en/latest/)
+  is a set of resources for running mybinder.org. It contains tips, snippets,
+  lessons-learned etc for running a large, public kubernetes cluster.
+* [**The JupyterHub Team Google Drive**](https://drive.google.com/drive/u/1/folders/0B8VZ4vaOYWZ3X29KTzZSemlNSG8)
+  is a place to store documents, presentations, images, etc that are useful to
+  the team. You can put whatever you'd like here, just try to keep it organized :-)
+
+## How can I help?
+   
+As a member of the team, you are encouraged to continue
+helping in the same ways that you already have. Your contributions to
+documentation, code, etc are always welcome, along with anything in the
+["how can I contribute"](https://jupyterhub-team-compass.readthedocs.io/en/latest/contributing.html)
+guide in the team-compass.
+   
+Don't forget that, as a member of the team, you're representing the community
+when you interact with people online. Try to keep a friendly, positive
+attitude, and be welcoming and helpful in bringing others into the community
+and answering their questions.
+   
+### Are there any specific responsibilies?
+   
+We don't want team membership to
+be a big burden (many of us have one or more other jobs too!) but there are
+a few things that you should do as a new team member:
+   
+1. **"Watch" the [team compass repository](https://github.com/jupyterhub/team-compass)**
+   so that you're notified when team conversations are happening.
+2. **"Watch" the [Discourse jupyterhub team category](https://discourse.jupyter.org/c/jupyterhub/internal)**
+   for the same reason.
+3. **Semi-regularly attend team meetings**. You can find a calendar of upcoming
+   meetings [on the team meetings page](https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html).
+4. **Follow the [Binder team responsibilities](https://jupyterhub-team-compass.readthedocs.io/en/latest/binder/governance.html#team-responsibilities) guidelines**.
+   While this is scoped for the Binder team, it is a good rubric to follow for
+   JupyterHub as well.
+   
+## When should I merge a pull request?
+
+As a team member, you're encouraged to help others contribute to the project
+by reviewing their code, guiding them towards making a contribution and
+improving it, and ultimately merging their contribution into the project.
+
+Having merge rights is both a privilege and a responsibility - please be
+thoughtful when using it! To that extent, here are a few guidelines when
+deciding to merge things into one of our repositories:
+
+* **Make sure it's quality code**. We know this is somewhat subjective, but
+  ensure that the code is well-organized and thoughtfully-written, that any
+  new features are documented, and that it abides by best-practices in Python,
+  JavaScript, etc.
+* **Make sure there are tests**. We try not to merge any new features (or
+  bugfixes!) without adding tests for them. It's easy to consider something
+  minor-enough that it doesn't warrant a test, but try to avoid doing this!
+  Adding tests usually only takes a moment, and our future selves will thank
+  us for it later.
+* **Make sure there's been enough time for discussion**. We're an open
+  community with an inclusive decision-making process. This means that
+  sometimes we need to slow down to make sure others have a chance to
+  review and provide their thoughts on changes. There's no hard rule for
+  this, but try to make sure people have a chance to weigh in. Consider
+  pinging people that you think might be interested in a question, and
+  give it a few extra days before merging if you think a topic will be
+  complex enough to warrant discussion.

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -16,9 +16,6 @@ a quick list to get you started.
 * [**The JupyterHub Team Compass issues**](https://github.com/jupyterhub/team-compass/issues)
   are where we often discuss specific, actionable things related to the *team*
   (e.g., discussing whether to change something in the team-compass repo).
-* [**The JupyterHub internal Discourse category**](https://discourse.jupyter.org/c/jupyterhub/internal)
-  is a place to have more general conversations between team members. It's only
-  viewable by members of the [JupyterHub Team Discourse Group](https://discourse.jupyter.org/g/jupyterhub-team).
 * **The JupyterHub gitter channels** are used to have synchronous conversation
   for several projects. If a conversation will likely span multiple hours,
   or is relevant to many people, consider opening a thread in Discourse or
@@ -59,11 +56,9 @@ a few things that you should do as a new team member:
    
 1. **"Watch" the [team compass repository](https://github.com/jupyterhub/team-compass)**
    so that you're notified when team conversations are happening.
-2. **"Watch" the [Discourse jupyterhub team category](https://discourse.jupyter.org/c/jupyterhub/internal)**
-   for the same reason.
-3. **Semi-regularly attend team meetings**. You can find a calendar of upcoming
+2. **Semi-regularly attend team meetings**. You can find a calendar of upcoming
    meetings [on the team meetings page](https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html).
-4. **Follow the [Binder team responsibilities](https://jupyterhub-team-compass.readthedocs.io/en/latest/binder/governance.html#team-responsibilities) guidelines**.
+3. **Follow the [Binder team responsibilities](https://jupyterhub-team-compass.readthedocs.io/en/latest/binder/governance.html#team-responsibilities) guidelines**.
    While this is scoped for the Binder team, it is a good rubric to follow for
    JupyterHub as well.
    
@@ -77,6 +72,9 @@ Having merge rights is both a privilege and a responsibility - please be
 thoughtful when using it! To that extent, here are a few guidelines when
 deciding to merge things into one of our repositories:
 
+* **Use your best judgment**. As a member of the JupyterHub teams, we trust
+  your judgment, and we ask you to use your best judgment in deciding when to
+  take an action.
 * **Make sure it's quality code**. We know this is somewhat subjective, but
   ensure that the code is well-organized and thoughtfully-written, that any
   new features are documented, and that it abides by best-practices in Python,
@@ -94,3 +92,10 @@ deciding to merge things into one of our repositories:
   pinging people that you think might be interested in a question, and
   give it a few extra days before merging if you think a topic will be
   complex enough to warrant discussion.
+* **Don't be afraid to merge!** We know this is a bit counter-intuitive
+  given what we just said, but don't be afraid to merge new code. If you
+  think a change is really complex or potentially controversial, give it
+  some time, but for most changes it is fine to just go ahead and merge.
+  Again, we trust your judgment, and we don't want these guidelines to become
+  a burden that slows down development.
+  


### PR DESCRIPTION
This adds onboarding documentation from #114 and #113. There were still some conversations to be finished there, so feel free to ask for changes etc. In particular @lheagy's suggestion about onboarding review processes etc is a good idea though I'm not sure where exactly to point people on that front...perhaps that's for another PR to include documentation about expected team behavior and opportunities to contribute?

I'm gonna follow the checklist to onboard @sgibson91 as well, follow along in https://github.com/jupyterhub/team-compass/issues/168

This closes #114 and #113 (though we will probably need to update these docs over time).