### PR TITLE
adding docs on talking about the project

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Site contents
    binder/governance
    binder/subdomains
    tools
+   talking
 
 Why have a Team Compass?
 ========================

--- a/docs/talking.rst
+++ b/docs/talking.rst
@@ -1,0 +1,66 @@
+.. _talking:
+
+================================================
+Talking about the JupyterHub and Binder Projects
+================================================
+
+The JupyterHub and Binder projects are both community-driven. This means that we
+rely on members of the community for spreading the word about these projects as well
+as the teams and communities around them.
+
+**If you have the opportunity to talk about the Binder or JupyterHub projects,
+please do so!** This might mean giving a presentation for your team, at a conference,
+in a tutorial session, or just talking to others on the internet.
+Our communities grow as we share our knowledge and experience with others.
+
+The rest of the resources on this page provide resources for folks who would like
+to talk about the JupyterHub and Binder projects.
+
+What to consider when speaking publicly about this community?
+=============================================================
+
+Here are a few simple rules to follow when speaking publicly about the Binder
+and JupyterHub projects.
+
+1. **Tell us if you're going to give a talk!** We'd love to hear when you are speaking
+   about the Binder or JupyterHub projects. If you'd like to give a talk
+   about these projects feel free to `open an issue to say hi <https://github.com/jupyterhub/team-compass/issues/new>`_.
+   We'll be excited to help you out and follow your talk.
+2. **Follow the Jupyter community conduct guidelines**. When you speak about the
+   Jupyter community, you represent that community. This means you should adhere to
+   the standards that the community defines in 
+   `the jupyter community code of conduct <https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md>`_.
+3. **Try to stick to the past and present**. We highly encourage folks to talk about
+   what the JupyterHub and Binder projects have been up to and where we are now. Talking
+   about the future is a bit trickier. A good rule of thumb is to avoid making specific
+   statements about what we're going to do next, unless we've explicitly said them already.
+4. **Give the community credit**. It's good practice to thank the Jupyter and Binder communities
+   liberally when giving talks about these projects. Everything that we do is only possible by
+   the amazing community of people that support the project - this community should always be
+   a part of your talk.
+
+For more general information about the Jupyter community and how to interface with it,
+check out the `Jupyter community documentation <https://jupyter.readthedocs.io/en/latest/community/content-community.html>`_.
+
+Resources for giving talks
+==========================
+
+We'd like for people to leverage and re-use the materials that others in the
+community have put together.
+
+`Check out this ongoing community forum thread <https://discourse.jupyter.org/t/resources-for-giving-talks-about-the-jupyterhub-and-binder-projects/1685>`_.
+for lots of helpful links to resources, slides, images, etc.
+You can use these as inspiration for your own talks, copy slides or sections, and improve upon them.
+
+If you'd like to add something to this list, please reply to that thread or edit the first
+comment with an updated link!
+
+Common questions and suggested answers
+======================================
+
+From time to time many of us get the same questions about how the JupyterHub and Binder
+projects work.
+
+`Check out this community forum thread <https://discourse.jupyter.org/t/binder-jupyterhub-common-questions-and-suggested-answers/1686>`_
+for an ongoing list of common questions and good answers. If you have questions that
+aren't listed there, please add them!


### PR DESCRIPTION
This adds a page with information about giving talks or just generally discussing the JupyterHub and Binder projects.

As a part of this PR there are also two new "wiki-style" community forum threads:

* https://discourse.jupyter.org/t/binder-jupyterhub-common-questions-and-suggested-answers/1686/2
* https://discourse.jupyter.org/t/resources-for-giving-talks-about-the-jupyterhub-and-binder-projects/1685/2

Would love to hear what folks think! In particular @betatim , @sgibson91 , and @kirstiejane who all had thoughts on this in the last team meeting

closes #179