### PR TITLE
updating team governance pages

### DIFF
--- a/docs/binder/governance.rst
+++ b/docs/binder/governance.rst
@@ -126,7 +126,7 @@ shift their focus in reaction to changing life circumstances.
 We ask that team members commit themselves in ~1 year cycles for new
 team members, and for shorter cycles if you are transitioning from the
 green team. If at any time a team member feels that they would
-like to take a break from active team membership, they're can choose
+like to take a break from active team membership, they can choose
 to join the "green team" by making a
 pull request to the `JupyterHub team membership <https://github.com/jupyterhub/team-compass/blob/master/docs/team/contributors-jupyterhub.yaml>`_
 or `Binder team membership <https://github.com/jupyterhub/team-compass/blob/master/docs/team/contributors-binder.yaml>`_

--- a/docs/binder/governance.rst
+++ b/docs/binder/governance.rst
@@ -85,7 +85,7 @@ team members, future team members and the community at large.
 
 We ask that you can commit to the above responsibilities for
 **at least 6 months** when joining the team. Training and mentoring new
-team members is an investment by the existing team, and team
+team members is an investment by the existing team, hence team
 membership requires commitment from both sides. Beyond 6 months, if active
 team membership is no longer possible for you, you can always
 join the green team! See :ref:`binder/time`.

--- a/docs/binder/governance.rst
+++ b/docs/binder/governance.rst
@@ -68,7 +68,7 @@ on the `discourse forum <http://discourse.jupyter.org/>`_.
 They should strive to make project decisions that reflect these
 community opinions.
 
-Team members are expected to keep themselves informed about issues and PRs on
+Team members are expected to *keep themselves informed about issues and PRs* on
 the `team-compass repository <https://github.com/jupyterhub/team-compass>`_. We
 use this repository for important discussions and decision making, sometimes
 with a timeframe of ~48h. One way to keep yourself informed is to "watch"
@@ -77,11 +77,18 @@ mechanisms that work for you.
 
 Because we ask all team members
 to watch this repository, please be respectful of others' time and attention,
-and try to keep conversations on-topic
+and try to keep conversations on-topic.
 
 Team members are expected to pass on their authority and responsibility
 to others by creating a open, transparent and inclusive culture for users,
 team members, future team members and the community at large.
+
+We ask that you can commit to the above responsibilities for
+**at least 6 months** when joining the team. Training and mentoring new
+team members is an investment by the existing team, and team
+membership requires commitment from both sides. Beyond 6 months, if active
+team membership is no longer possible for you, you can always
+join the green team! See :ref:`binder/time`.
 
 This list is non-complete.
 
@@ -114,6 +121,8 @@ Team roles
 There are no other specific roles, but we may revisit this in the
 future.
 
+.. _binder/time:
+
 A note on team membership and growth over time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -123,7 +132,7 @@ pass their organizational responsibilities on to them. This encourages
 us to increase diversity, reduce burn-out and allow team members to
 shift their focus in reaction to changing life circumstances.
 
-We ask that team members commit themselves in ~1 year cycles for new
+We ask that team members commit themselves in ~6 month cycles for new
 team members, and for shorter cycles if you are transitioning from the
 green team. If at any time a team member feels that they would
 like to take a break from active team membership, they can choose

--- a/docs/binder/governance.rst
+++ b/docs/binder/governance.rst
@@ -97,24 +97,14 @@ Team roles
    ``mybinder.org``. You are expected to coordinate your actions with
    other red members so that the project presents a coherent position
    towards the outside. You are expected to prepare and attend the
-   monthly team calls. Being a red member is not a life sentence. We
-   expect red members to teach and grow other members so that they can
-   pass their organizational responsibilities on to them. This encourages
-   us to increase diversity, reduce burn-out and allow team members to
-   shift their focus in reaction to changing life circumstances. Your change
-   of focus will be announced at the next monthly team meeting.
+   monthly team calls.
 -  **Blue member.** This is where the journey of a new team member starts.
    You spend a large
    part of your time facilitating contributions from others to the
    project (e.g. reviewing work, answering questions, maintaining
-   project infrastructure). We expect blue members to teach and grow
-   contributors that can become blue members. This encourages diversity
-   of the team. After building a good understanding of the technology
+   project infrastructure). After building a good understanding of the technology
    and social structure of the project you can change to a red member by
    volunteering for tasks which a red member is expected to perform.
-   After a while of doing so the team will ask if you want to become a
-   red member and, if you agree, recognise you as such at a monthly team
-   meeting.
 -  **Green member.** Your life situation has changed so that you prefer to
    (temporarily) not take on the rights and responsibilities of being an
    active member. You can return to active membership by resuming your
@@ -123,6 +113,24 @@ Team roles
 
 There are no other specific roles, but we may revisit this in the
 future.
+
+A note on team membership and growth over time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Being a team member is not a life sentence. We
+expect team members to teach and grow other members so that they can
+pass their organizational responsibilities on to them. This encourages
+us to increase diversity, reduce burn-out and allow team members to
+shift their focus in reaction to changing life circumstances.
+
+We ask that team members commit themselves in ~1 year cycles for new
+team members, and for shorter cycles if you are transitioning from the
+green team. If at any time a team member feels that they would
+like to take a break from active team membership, they're can choose
+to join the "green team" by making a
+pull request to the `JupyterHub team membership <https://github.com/jupyterhub/team-compass/blob/master/docs/team/contributors-jupyterhub.yaml>`_
+or `Binder team membership <https://github.com/jupyterhub/team-compass/blob/master/docs/team/contributors-binder.yaml>`_
+files.
 
 How decisions are made
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -151,6 +159,6 @@ Modus operandi
 All team business is conducted in public.
 
 .. _as colleagues: https://en.wikipedia.org/wiki/Collegiality
-.. _privileges: https://hackmd.io/UYG1jAM9TO-bqm9yNdXyYA?both#Team-privileges
-.. _responsibilities: https://hackmd.io/UYG1jAM9TO-bqm9yNdXyYA?both#Team-expectations
+.. _privileges: https://jupyterhub-team-compass.readthedocs.io/en/latest/binder/governance.html#team-privileges
+.. _responsibilities: https://jupyterhub-team-compass.readthedocs.io/en/latest/binder/governance.html#team-expectations
 .. _the BinderHub team: https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html#binder-team

--- a/docs/governance.rst
+++ b/docs/governance.rst
@@ -82,7 +82,7 @@ pass their organizational responsibilities on to them. This encourages
 us to increase diversity, reduce burn-out and allow team members to
 shift their focus in reaction to changing life circumstances.
 
-We ask that team members commit themselves in ~1 year cycles for new
+We ask that team members commit themselves in ~6 month cycles for new
 team members, and for shorter cycles if you are transitioning from the
 green team. If at any time a team member feels that they would
 like to take a break from active team membership, they're can choose

--- a/docs/governance.rst
+++ b/docs/governance.rst
@@ -1,0 +1,122 @@
+.. _jupyterhub-governance:
+
+JupyterHub Project Governance
+=============================
+
+The following sections describe governance and high-level principles
+surrounding the JupyterHub Project.
+
+The JupyterHub Project is a member of Project Jupyter, which is a fiscally
+sponsored project of NumFocus, a US 501c3 non-profit.
+
+Project mission
+~~~~~~~~~~~~~~~
+
+The mission of the JupyterHub Project is to create, advance, and promote
+open technology that enables interactive computing sessions via shared
+infrastructure.
+
+The JupyterHub Project pursues this mission by advancing the tools
+surrounding JupyterHub, an open-source tool for hosting Jupyter
+user sessions on shared infrastructure.
+
+.. _jupyterhub-team-membership:
+
+Membership
+~~~~~~~~~~
+
+Membership in the JupyterHub Project is open to anyone who is nominated by
+an existing member. Members form the trusted group of individuals who
+manage the JupyterHub Project.
+
+Membership comes with `privileges`_ and `responsibilities`_.
+
+The authoritative list of members and their roles (alphabetical sorting)
+can be found at the :ref:`jupyterhub-team` section.
+
+Team privileges
+~~~~~~~~~~~~~~~
+
+-  recognition
+-  team members can speak for the project in public
+-  merge privileges on the project repositories
+-  nominating other individuals to team membership
+
+.. _jupyterhub-team-responsibilities:
+
+Team responsibilities
+~~~~~~~~~~~~~~~~~~~~~
+
+The JupyterHub team responsibilities are outlined in the
+`JupyterHub team member guide <https://jupyterhub-team-compass.readthedocs.io/en/latest/team/member-guide.html>`_.
+
+Team roles
+~~~~~~~~~~
+
+-  **Team leader.** This is a person who has impasse-breaking authority to
+   make decisions if the team can not agree. This authority should
+   be used exceedingly sparingly. The team leader is expected to grow
+   team members so that they can pass on their position to them.
+-  **Team member.** You spend a large part of your time coordinating and
+   promoting the JupyterHub Project, helping new contributors learn and
+   grow within the community, and contribute to the JupyterHub repositories.
+   You are expected to prepare and attend the monthly team calls on a
+   semi-regular basis. We expect team members to teach and grow
+   contributors that can join the team. This encourages diversity
+   of the team.
+-  **Green member.** Your life situation has changed so that you prefer to
+   (temporarily) not take on the rights and responsibilities of being an
+   active member. You can return to active membership by resuming your
+   community activities. Your return will be announced at the next monthly
+   team meeting.
+
+There are no other specific roles, but we may revisit this in the
+future.
+
+A note on team membership over time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Being a team member is not a life sentence. We
+expect team members to teach and grow other members so that they can
+pass their organizational responsibilities on to them. This encourages
+us to increase diversity, reduce burn-out and allow team members to
+shift their focus in reaction to changing life circumstances.
+
+We ask that team members commit themselves in ~1 year cycles for new
+team members, and for shorter cycles if you are transitioning from the
+green team. If at any time a team member feels that they would
+like to take a break from active team membership, they're can choose
+to join the "green team" by making a
+pull request to the `JupyterHub team membership <https://github.com/jupyterhub/team-compass/blob/master/docs/team/contributors-jupyterhub.yaml>`_
+or `Binder team membership <https://github.com/jupyterhub/team-compass/blob/master/docs/team/contributors-binder.yaml>`_
+files.
+
+How decisions are made
+~~~~~~~~~~~~~~~~~~~~~~
+
+The JupyterHub Project team will make decisions `as colleagues`_ and by
+attempting to reach consensus among team members (similar to a
+`lazy consensus <http://en.osswiki.info/concepts/lazy_consensus>`_ model that
+encourages active participation from team members). If this is not
+possible, then the team leader can use their power to make a decision.
+
+There is currently no formal specification for this decision process.
+
+Team size
+~~~~~~~~~
+
+There is no limit to the size of the team.
+
+There is no hard cap on the number of senior members that can exist,
+though this will be re-evaluate if the group becomes big enough to be
+unwieldy. We see the ideal number of red team members to be around 6-10
+people.
+
+Modus operandi
+~~~~~~~~~~~~~~
+
+All team business is conducted in public.
+
+.. _as colleagues: https://en.wikipedia.org/wiki/Collegiality
+.. _privileges: https://jupyterhub-team-compass.readthedocs.io/en/latest/governance.html#team-privileges
+.. _responsibilities: https://jupyterhub-team-compass.readthedocs.io/en/latest/governance.html#team-expectations

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,22 +15,39 @@ with the JupyterHub community. For more some more technical information
 and links to various JupyterHub repositories, see the
 `Team Compass README <https://github.com/jupyterhub/team-compass>`_.
 
-Site contents
-=============
+Team Compass Resources
+======================
+
+The following pages contain information about the JupyterHub/Binder
+teams, resources for community members, and team practices for
+governance and planning.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
+   :caption: The JupyterHub Teams
 
    team
    contributing
    meetings
-   milestones
-   team/adding-members
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Team Guides and Resources
+
    team/member-guide
-   binder/governance
-   binder/subdomains
    tools
    talking
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Governance and roadmaps
+
+   team/adding-members
+   binder/governance
+   binder/subdomains
+   milestones
+
+
 
 Why have a Team Compass?
 ========================

--- a/docs/team.rst
+++ b/docs/team.rst
@@ -1,8 +1,8 @@
 .. _core_team:
 
-========================
-The JupyterHub Community
-========================
+=======================================
+The JupyterHub Core Teams and Community
+=======================================
 
 There are lots of ways to contribute to the JupyterHub community.
 Code, community interaction, documentation, bug testing, bug fixes, teaching,

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -63,6 +63,11 @@ a few things that you should do as a new team member:
 3. **Follow the [Binder team responsibilities](https://jupyterhub-team-compass.readthedocs.io/en/latest/binder/governance.html#team-responsibilities) guidelines**.
    While this is scoped for the Binder team, it is a good rubric to follow for
    JupyterHub as well.
+4. **Commit at least 6 months to team membership**. Training and mentoring new
+   team members is an investment by the existing team, and team
+   membership requires commitment from both sides. Beyond 6 months, if active
+   team membership is no longer possible for you, you can always
+   join the green team!
 
 ## When should I merge a pull request?
 

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -1,14 +1,14 @@
-# JupyterHub team guide
-      
+# JupyterHub and Binder team guide
+
 This page holds resources for members of the JupyterHub and Binder teams.
 They're meant to guide team members to be happy, productive members of the
 team!
 
 ## What are the team resources?
-   
+
 There are a few resources that are particularly useful for team members. Here's
 a quick list to get you started.
-   
+
 * [**The JupyterHub Team Compass**](https://jupyterhub-team-compass.readthedocs.io/en/latest/contributing.html)
   is a repository with lots of information about team-related things. It has
   development tips, information about team meetings, milestones and roadmaps,
@@ -36,24 +36,26 @@ a quick list to get you started.
   the team. You can put whatever you'd like here, just try to keep it organized :-)
 
 ## How can I help?
-   
+
 As a member of the team, you are encouraged to continue
 helping in the same ways that you already have. Your contributions to
 documentation, code, etc are always welcome, along with anything in the
 ["how can I contribute"](https://jupyterhub-team-compass.readthedocs.io/en/latest/contributing.html)
-guide in the team-compass.
-   
+guide in the team-compass. If you're on the Binder team, then check out
+[the Binder team responsibilities](https://jupyterhub-team-compass.readthedocs.io/en/latest/binder/governance.html#team-responsibilities)
+page for more information.
+
 Don't forget that, as a member of the team, you're representing the community
 when you interact with people (online and offline). Try to keep a friendly, positive
 attitude, and be welcoming and helpful in bringing others into the community
 and answering their questions.
-   
+
 ### Are there any specific responsibilies?
-   
+
 We don't want team membership to
 be a big burden (many of us have one or more other jobs too!) but there are
 a few things that you should do as a new team member:
-   
+
 1. **"Watch" the [team compass repository](https://github.com/jupyterhub/team-compass)**
    so that you're notified when team conversations are happening.
 2. **Semi-regularly attend team meetings**. You can find a calendar of upcoming
@@ -61,7 +63,7 @@ a few things that you should do as a new team member:
 3. **Follow the [Binder team responsibilities](https://jupyterhub-team-compass.readthedocs.io/en/latest/binder/governance.html#team-responsibilities) guidelines**.
    While this is scoped for the Binder team, it is a good rubric to follow for
    JupyterHub as well.
-   
+
 ## When should I merge a pull request?
 
 As a team member, you're encouraged to help others contribute to the project
@@ -98,4 +100,3 @@ deciding to merge things into one of our repositories:
   some time, but for most changes it is fine to just go ahead and merge.
   Again, we trust your judgment, and we don't want these guidelines to become
   a burden that slows down development.
-  

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -64,7 +64,7 @@ a few things that you should do as a new team member:
    While this is scoped for the Binder team, it is a good rubric to follow for
    JupyterHub as well.
 4. **Commit at least 6 months to team membership**. Training and mentoring new
-   team members is an investment by the existing team, and team
+   team members is an investment by the existing team, hence team
    membership requires commitment from both sides. Beyond 6 months, if active
    team membership is no longer possible for you, you can always
    join the green team!


### PR DESCRIPTION
This PR does a couple of things on the team compass repo to try and add missing information and reorganize to make things easier to find.

* Adds a JupyterHub governance page - this is largely a copy of the Binder governance page with a few modifications to fit the JupyterHub team dynamics
  * This includes the following JupyterHub team roles: Team Leader, Team Member, Green Team.
* Adds captions to the TOCs so that we get headings in the left menu
* Adds an explicit section on moving between teams and joining the green team.
* Renames a couple things to make them easier to find

closes #192 