### PR TITLE
[WIP] adding team check-in process

### DIFF
--- a/docs/team/contributors-binder.yaml
+++ b/docs/team/contributors-binder.yaml
@@ -4,76 +4,76 @@
   affiliation: UC Berkeley
   contributions: doc
   team: red
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Sarah Gibson
   handle: "@sgibson91"
   affiliation: The Alan Turing Institute
   contributions: question,doc,tutorial
   team: blue
-  last-check-in: 2019-05
+  last-check-in: 2019-10
 
 - name: Tim Head
   handle: "@betatim"
   affiliation: Wild Tree Tech
   contributions: ""
   team: red
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Lindsey Heagy
   handle: "@lheagy"
   affiliation: UC Berkeley
   contributions: ideas,example
   team: blue
-  last-check-in: 2019-01
+  last-check-in: 2019-10
 
 - name: Chris Holdgraf
   handle: "@choldgraf"
   affiliation: Berkeley Institute for Data Science
   contributions: code,ideas,doc,question
   team: red
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: M Pacer
   handle: "@mpacer"
   affiliation: Netflix
   contributions: ""
   team: blue
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Yuvi Panda
   handle: "@yuvipanda"
   affiliation: UC Berkeley
   contributions: "code,infra"
   team: blue
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Min Ragan-Kelley
   handle: "@minrk"
   affiliation: Simula
   contributions: data,code
   team: lead
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Zach Sailer
   handle: "@Zsailer"
   affiliation: Project Jupyter
   contributions: code,ideas,question
   team: blue
-  last-check-in: 2019-01
+  last-check-in: 2019-10
 
 - name: Erik Sundell
   handle: "@consideRatio"
   affiliation: Sandvik CODE
   contributions: code,infra
   team: blue
-  last-check-in: 2019-01
+  last-check-in: 2019-10
 
 - name: Carol Willing
   handle: "@willingc"
   affiliation: Project Jupyter
   contributions: Python,Community
   team: red
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 # Green team members at the end, also alphabetical

--- a/docs/team/contributors-binder.yaml
+++ b/docs/team/contributors-binder.yaml
@@ -4,65 +4,76 @@
   affiliation: UC Berkeley
   contributions: doc
   team: red
-  
+  last-check-in: 2018-11
+
 - name: Sarah Gibson
   handle: "@sgibson91"
   affiliation: The Alan Turing Institute
   contributions: question,doc,tutorial
   team: blue
+  last-check-in: 2019-05
 
 - name: Tim Head
   handle: "@betatim"
   affiliation: Wild Tree Tech
   contributions: ""
   team: red
+  last-check-in: 2018-11
 
 - name: Lindsey Heagy
   handle: "@lheagy"
   affiliation: UC Berkeley
   contributions: ideas,example
   team: blue
+  last-check-in: 2019-01
 
 - name: Chris Holdgraf
   handle: "@choldgraf"
   affiliation: Berkeley Institute for Data Science
   contributions: code,ideas,doc,question
   team: red
+  last-check-in: 2018-11
 
 - name: M Pacer
   handle: "@mpacer"
   affiliation: Netflix
   contributions: ""
   team: blue
+  last-check-in: 2018-11
 
 - name: Yuvi Panda
   handle: "@yuvipanda"
   affiliation: UC Berkeley
   contributions: "code,infra"
   team: blue
+  last-check-in: 2018-11
 
 - name: Min Ragan-Kelley
   handle: "@minrk"
   affiliation: Simula
   contributions: data,code
   team: lead
+  last-check-in: 2018-11
 
 - name: Zach Sailer
   handle: "@Zsailer"
   affiliation: Project Jupyter
   contributions: code,ideas,question
   team: blue
+  last-check-in: 2019-01
 
 - name: Erik Sundell
   handle: "@consideRatio"
   affiliation: Sandvik CODE
   contributions: code,infra
   team: blue
+  last-check-in: 2019-01
 
 - name: Carol Willing
   handle: "@willingc"
   affiliation: Project Jupyter
   contributions: Python,Community
   team: red
+  last-check-in: 2018-11
 
 # Green team members at the end, also alphabetical

--- a/docs/team/contributors-jupyterhub.yaml
+++ b/docs/team/contributors-jupyterhub.yaml
@@ -4,60 +4,60 @@
   affiliation: UC Merced
   contributions: code,infra
   team: jupyterhub
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Georgiana Dolocan
   handle: "@GeorgianaElena"
   affiliation: Simula
   contributions: code
   team: jupyterhub
-  last-check-in: 2019-07
+  last-check-in: 2019-10
 
 - name: Jessica Forde
   handle: "@jzf2101"
   affiliation: UC Berkeley
   contributions: doc
   team: jupyterhub
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Chris Holdgraf
   handle: "@choldgraf"
   affiliation: Berkeley Institute for Data Science
   contributions: code,ideas,doc,question
   team: jupyterhub
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Yuvi Panda
   handle: "@yuvipanda"
   affiliation: UC Berkeley
   contributions: "code,infra"
   team: jupyterhub
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Min Ragan-Kelley
   handle: "@minrk"
   affiliation: Simula
   contributions: code,infra
   team: jupyterhub
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Zach Sailer
   handle: "@Zsailer"
   affiliation: Project Jupyter
   contributions: code,ideas,question
   team: jupyterhub
-  last-check-in: 2019-01
+  last-check-in: 2019-10
 
 - name: Erik Sundell
   handle: "@consideRatio"
   affiliation: Sandvik CODE
   contributions: code,infra
   team: jupyterhub
-  last-check-in: 2018-11
+  last-check-in: 2019-10
 
 - name: Carol Willing
   handle: "@willingc"
   affiliation: Project Jupyter
   contributions: Python,Community
   team: jupyterhub
-  last-check-in: 2018-11
+  last-check-in: 2019-10

--- a/docs/team/contributors-jupyterhub.yaml
+++ b/docs/team/contributors-jupyterhub.yaml
@@ -3,43 +3,61 @@
   handle: "@carreau"
   affiliation: UC Merced
   contributions: code,infra
+  team: jupyterhub
+  last-check-in: 2018-11
 
 - name: Georgiana Dolocan
   handle: "@GeorgianaElena"
   affiliation: Simula
   contributions: code
+  team: jupyterhub
+  last-check-in: 2019-07
 
 - name: Jessica Forde
   handle: "@jzf2101"
   affiliation: UC Berkeley
   contributions: doc
+  team: jupyterhub
+  last-check-in: 2018-11
 
 - name: Chris Holdgraf
   handle: "@choldgraf"
   affiliation: Berkeley Institute for Data Science
   contributions: code,ideas,doc,question
+  team: jupyterhub
+  last-check-in: 2018-11
 
 - name: Yuvi Panda
   handle: "@yuvipanda"
   affiliation: UC Berkeley
   contributions: "code,infra"
+  team: jupyterhub
+  last-check-in: 2018-11
 
 - name: Min Ragan-Kelley
   handle: "@minrk"
   affiliation: Simula
   contributions: code,infra
+  team: jupyterhub
+  last-check-in: 2018-11
 
 - name: Zach Sailer
   handle: "@Zsailer"
   affiliation: Project Jupyter
   contributions: code,ideas,question
+  team: jupyterhub
+  last-check-in: 2019-01
 
 - name: Erik Sundell
   handle: "@consideRatio"
   affiliation: Sandvik CODE
   contributions: code,infra
+  team: jupyterhub
+  last-check-in: 2018-11
 
 - name: Carol Willing
   handle: "@willingc"
   affiliation: Project Jupyter
   contributions: Python,Community
+  team: jupyterhub
+  last-check-in: 2018-11

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -68,6 +68,9 @@ a few things that you should do as a new team member:
    membership requires commitment from both sides. Beyond 6 months, if active
    team membership is no longer possible for you, you can always
    join the green team!
+5. **Let us know if you'll be unavailable** or out of town for an extended period
+   of time. It's no problem if you need to focus on other things for a bit, but it's
+   helpful for the team to know who will be around.
 
 ## When should I merge a pull request?
 
@@ -105,3 +108,56 @@ deciding to merge things into one of our repositories:
   some time, but for most changes it is fine to just go ahead and merge.
   Again, we trust your judgment, and we don't want these guidelines to become
   a burden that slows down development.
+
+## Periodic team check-ins
+
+We want team membership to be an opportunity to grow and have an impact, not
+a burden or a time sink. While we ask for a minimum 6 month commitment when
+you join a JupyterHub or Binder team, we don't expect this commitment to
+last forever.
+
+In order to ensure that team membership is still the best option for you,
+we try to conduct regular "check-ins" approximately once every 6 months.
+Its goal is to make sure that you're happy in your current position with the JupyterHub project,
+and discuss whether you'd like to continue in your current role, transition to
+a different role, or transition to the green team.
+
+These check-ins happen via GitHub issues on the team compass repository,
+here's the issue text to use:
+
+```
+Title: Team check-in for choldgraf
+Body:
+
+Hello <username>, this is a [team check-in](<link to this docs page>) for your JupyterHub team status.
+Please respond below if you're interested in either:
+
+* Continuing in your current role
+* Moving to a new role
+* Moving to the green team
+
+There's no pressure one way or another, this is just to check that you're still
+comfortable with the role, responsibilities, etc for your current position.
+```
+
+There's no pressure or expectation associated with these check-ins, their goal
+is to make sure that team members have an opportunity to voice their perspective
+and choose their next steps within the community.
+
+If you decide to change team status, we'll make a PR either to the
+[BinderHub team data page](https://github.com/jupyterhub/team-compass/blob/master/docs/team/contributors-binder.yaml)
+or the [JupyterHub team data page](https://github.com/jupyterhub/team-compass/blob/master/docs/team/contributors-jupyterhub.yaml).
+Either way, we'll update the latest time that you had a check-in.
+
+### If a team member doesn't respond to a check-in
+
+Sometimes team members aren't able to respond to check-ins. This is no problem -
+other duties, life, vacation, etc often get in the way. In this case,
+we'll try to reach out with the following steps.
+
+- First, we'll ping team members in their check-in issue to maximize likelihood of notifications
+- After 7 days, we'll ping the issue again with a "maybe you missed this" comment
+- After 14 days, we'll send an email
+- After 21 days, we'll send a follow-up email to double-check your availability.
+- After 30 days if you haven't responded, we'll move you to the green team
+- You can move back into another team whenever you like - just reach out and we'll revert the change.

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -116,9 +116,8 @@ a burden or a time sink. While we ask for a minimum 6 month commitment when
 you join a JupyterHub or Binder team, we don't expect this commitment to
 last forever.
 
-In order to ensure that team membership is still the best option for you,
-we try to conduct regular "check-ins" approximately once every 6 months.
-Its goal is to make sure that you're happy in your current position with the JupyterHub project,
+We try to conduct regular "check-ins" for team members approximately once every 6 months.
+The goal is to make sure that you're happy in your current position with the JupyterHub project,
 and discuss whether you'd like to continue in your current role, transition to
 a different role, or transition to the green team.
 
@@ -137,7 +136,7 @@ Please respond below if you're interested in either:
 * Moving to the green team
 
 There's no pressure one way or another, this is just to check that you're still
-comfortable with the role, responsibilities, etc for your current position.
+comfortable with the role and responsibilities for your current position.
 ```
 
 There's no pressure or expectation associated with these check-ins, their goal

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -71,6 +71,10 @@ a few things that you should do as a new team member:
 5. **Let us know if you'll be unavailable** or out of town for an extended period
    of time. It's no problem if you need to focus on other things for a bit, but it's
    helpful for the team to know who will be around.
+   To do so, [open an issue in the team-compass](https://github.com/jupyterhub/team-compass/issues/new).
+   If it's something you'd rather not mention to the public then
+   send an email to one of the team members letting them know, and they
+   can communicate it to the others.
 
 ## When should I merge a pull request?
 


### PR DESCRIPTION
This is a first attempt at codifying a team check-in process for team members, following a conversation in #186.

I am hoping that this is perceived as a positive thing by folks - an opportunity for them to decide if they wish to continue in their current roles or move to something else. If folks think that it comes across as pushy or unreasonable, please do not hesitate to give that feedback.

Am happy to iterate on language, specific processes, etc. I imagine there is still a bit of discussion to have around this.

## todo

- [ ] Add a note that there is no change in permissions or authority etc if you move to the green team!