### PR TITLE
Move people to the green team

### DIFF
--- a/docs/team/contributors-binder.yaml
+++ b/docs/team/contributors-binder.yaml
@@ -20,13 +20,6 @@
   team: red
   last-check-in: 2019-10
 
-- name: Lindsey Heagy
-  handle: "@lheagy"
-  affiliation: UC Berkeley
-  contributions: ideas,example
-  team: blue
-  last-check-in: 2019-10
-
 - name: Chris Holdgraf
   handle: "@choldgraf"
   affiliation: Berkeley Institute for Data Science
@@ -38,13 +31,6 @@
   handle: "@mpacer"
   affiliation: Netflix
   contributions: ""
-  team: blue
-  last-check-in: 2019-10
-
-- name: Yuvi Panda
-  handle: "@yuvipanda"
-  affiliation: UC Berkeley
-  contributions: "code,infra"
   team: blue
   last-check-in: 2019-10
 
@@ -77,3 +63,16 @@
   last-check-in: 2019-10
 
 # Green team members at the end, also alphabetical
+- name: Lindsey Heagy
+  handle: "@lheagy"
+  affiliation: UC Berkeley
+  contributions: ideas,example
+  team: green
+  last-check-in: 2019-10
+
+- name: Yuvi Panda
+  handle: "@yuvipanda"
+  affiliation: UC Berkeley
+  contributions: "code,infra"
+  team: green
+  last-check-in: 2019-10


### PR DESCRIPTION
This PR makes a start with moving some people who have not been active and don't expect to become active again in the near future to the green team. As soon as they do become active again they can of course move back to the blue or red team.

The reason for keeping our team assignments somewhat up to date is (like the Python core team says [towards the bottom of this section](https://www.python.org/dev/peps/pep-0013/#membership)) to provide a reasonable estimate of how many people are actively working on the project.

This moves @yuvipanda and @lheagy because I've managed to get hold of them to discuss this before opening the PR. Thanks for being reachable and taking the time to think about this you two :)

There are two more people in the Binder team who I will try and contact privately before taking any action. We have added some language to the governance doc about people's team assignment moving towards green if they aren't active. However I think being pro-active is better than just waiting for nature to take its course.