### PR TITLE
Move myself (Zsailer) to the Green Team

### DIFF
--- a/docs/team/contributors-binder.yaml
+++ b/docs/team/contributors-binder.yaml
@@ -41,13 +41,6 @@
   team: lead
   last-check-in: 2019-10
 
-- name: Zach Sailer
-  handle: "@Zsailer"
-  affiliation: Project Jupyter
-  contributions: code,ideas,question
-  team: blue
-  last-check-in: 2019-10
-
 - name: Erik Sundell
   handle: "@consideRatio"
   affiliation: Sandvik CODE
@@ -74,5 +67,12 @@
   handle: "@yuvipanda"
   affiliation: UC Berkeley
   contributions: "code,infra"
+  team: green
+  last-check-in: 2019-10
+
+- name: Zach Sailer
+  handle: "@Zsailer"
+  affiliation: Project Jupyter
+  contributions: code,ideas,question
   team: green
   last-check-in: 2019-10

--- a/docs/team/contributors-jupyterhub.yaml
+++ b/docs/team/contributors-jupyterhub.yaml
@@ -55,13 +55,6 @@
   team: jupyterhub
   last-check-in: 2019-10
 
-- name: Zach Sailer
-  handle: "@Zsailer"
-  affiliation: Project Jupyter
-  contributions: code,ideas,question
-  team: jupyterhub
-  last-check-in: 2019-10
-
 - name: Erik Sundell
   handle: "@consideRatio"
   affiliation: Sandvik CODE


### PR DESCRIPTION
Moving myself to the green team (following #262).

It doesn't look like we have the same red-blue-green team structure under JupyterHub, so I just went ahead and removed myself completely from the JupyterHub section. Let me know if I missed anything.

Thanks, y'all! 