### PR TITLE
Document the support bot

### DIFF
--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -51,7 +51,8 @@ transition easier for both developers and users, we have plugged into the reposi
 of the JupyterHub organization a [support bot](https://github.com/jupyterhub/.github/blob/master/.github/support.yml).
 The bot will post a short and sweet message to inform the contributor about our communication policy
 and will then close the issue. This support bot will act each time the `support` label is added
-to an issue.
+to an issue. Don't worry if you mistakenly label an issue as `support`. The action is reversible
+and removing the label will reopen the issue.
 
 We kindly encourage everybody to use the bot, if during this transition phase, any issues that
 should be on Discourse, are opened on GitHub.

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -35,6 +35,27 @@ a quick list to get you started.
   is a place to store documents, presentations, images, etc that are useful to
   the team. You can put whatever you'd like here, just try to keep it organized :-)
 
+### General policy about communication channels
+
+We are trying to organize our discussions in order to help both contributors and
+maintainers find and choose the right communication channels and have a positive experience :-)
+
+In this respect, we are using:
+1. GitHub issues for specific discussions related to changing a repository's content
+(e.g. feature requests, bug reports).
+2. The [Discourse forum](http://discourse.jupyter.org/) for general discussions, support
+questions, or just as a place where we can inspire each other.
+
+To support our effors in organizing the communication channels and make the
+transition easier for both developers and users, we have plugged into the repositories
+of the JupyterHub organization a [support bot](https://github.com/jupyterhub/.github/blob/master/.github/support.yml).
+The bot will post a short and sweet message to inform the contributor about our communication policy
+and will then close the issue. This support bot will act each time the `support` label is added
+to an issue.
+
+We kindly encourage everybody to use the bot, if during this transition phase, any issues that
+should be on Discourse, are opened on GitHub.
+
 ## How can I help?
 
 As a member of the team, you are encouraged to continue

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -50,6 +50,13 @@ To support our efforts in organizing the communication channels and make the
 transition easier for both developers and users, we have plugged into the repositories
 of the JupyterHub organization a [support bot](https://github.com/jupyterhub/.github/blob/master/.github/support.yml).
 
+---
+Currently, the bot will only check the following repositories:
+* [binderhub](https://github.com/jupyterhub/binderhub)
+* [jupyterhub](https://github.com/jupyterhub/jupyterhub)
+* [the-littlest-jupyterhub](https://github.com/jupyterhub/the-littlest-jupyterhub)
+---
+
 **To trigger the support bot on an issue**, add the `support` label to an issue.
 The bot will post a short and sweet message to inform the contributor about our communication policy
 and will then close the issue. This support bot will act each time the `support` label is added

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -49,6 +49,8 @@ questions, or just as a place where we can inspire each other.
 To support our efforts in organizing the communication channels and make the
 transition easier for both developers and users, we have plugged into the repositories
 of the JupyterHub organization a [support bot](https://github.com/jupyterhub/.github/blob/master/.github/support.yml).
+
+**To trigger the support bot on an issue**, add the `support` label to an issue.
 The bot will post a short and sweet message to inform the contributor about our communication policy
 and will then close the issue. This support bot will act each time the `support` label is added
 to an issue. Don't worry if you mistakenly label an issue as `support`. The action is reversible

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -46,7 +46,7 @@ In this respect, we are using:
 2. The [Discourse forum](http://discourse.jupyter.org/) for general discussions, support
 questions, or just as a place where we can inspire each other.
 
-To support our effors in organizing the communication channels and make the
+To support our efforts in organizing the communication channels and make the
 transition easier for both developers and users, we have plugged into the repositories
 of the JupyterHub organization a [support bot](https://github.com/jupyterhub/.github/blob/master/.github/support.yml).
 The bot will post a short and sweet message to inform the contributor about our communication policy


### PR DESCRIPTION
Documents the process of moving the support questions on Discourse and the addition of  the `support bot`.

What do people think about this? :sunny:  Is the *members guide* section the right place to add this info?

Relevant refs:
* https://github.com/jupyterhub/jupyterhub/issues/2996
* https://github.com/jupyterhub/team-compass/issues/271
* [April team meeting agenda](https://hackmd.io/u2ghJJUCRWK-zRidCFid_Q?view)