### PR TITLE
Add July team meeting minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Most of the Team Compass lives in this website:
 ## Team information
 
 [![team website](https://img.shields.io/badge/team-website-orange.svg)](https://jupyterhub-team-compass.readthedocs.io/en/latest/)
-[![monthly agenda](https://img.shields.io/badge/agenda-this%20month-blue.svg)](https://hackmd.io/u2ghJJUCRWK-zRidCFid_Q?view)
+[![monthly agenda](https://img.shields.io/badge/agenda-this%20month-blue.svg)](https://hackmd.io/@sgibson91/hubs-team-meeting)
 
 **Documentation status and codecov for several repositories**
 

--- a/docs/monthly-meeting/2020-07-16.md
+++ b/docs/monthly-meeting/2020-07-16.md
@@ -2,9 +2,9 @@
 
 - **Date:** Thursday 16th July, 2020
 - **Time:** 5pm UTC
-  - **Your timezone:** https://arewemeetingyet.com/UTC/2020-07-16/17:00/Hubs%20Team%20Meeting
-- **GitHub issue:** https://github.com/jupyterhub/team-compass/issues/308
-- **Calendar for future meetings:** https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html
+  - **Your timezone:** <https://arewemeetingyet.com/UTC/2020-07-16/17:00/Hubs%20Team%20Meeting>
+- **GitHub issue:** <https://github.com/jupyterhub/team-compass/issues/308>
+- **Calendar for future meetings:** <https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html>
 
 ## Welcome to the Team Meeting
 
@@ -15,17 +15,17 @@ If you are joining the team video meeting, sign in below so we know who was here
 - name / institution / GitHub handle
 - Min / Simula / @minrk
 - Sarah / Turing / @sgibson91
-- Hamel / GitHub / [@hamelsmu](https://www.github.com/hamelsmu)
+- Hamel / GitHub / @hamelsmu
 - Chris / Berkeley / @choldgraf
-- Matthew / Illinois & PyHEP / [@matthewfeickert](https://www.github.com/matthewfeickert)
+- Matthew / Illinois & PyHEP / @matthewfeickert
 - Tim / Binder/ @betatim
 - Steve / AWS / @blink1073
 - Darian / Two Sigma / @afshin
 - Georgiana / CIR / @GeorgianaElena
 - Richard / Aalto / @rkdarst
-- Erik / Sundell Open Source / [@consideRatio](https://www.github.com/consideRatio)
+- Erik / Sundell Open Source / @consideRatio
 - Rollin / NERSC / @rcthomas
-- Michael / Code for Philly / [@machow](http://github.com/machow)
+- Michael / Code for Philly / @machow
 - Simon Li / OME, University of Dundee / @manics
 - Zach Sailer / Jupyter Cal Poly / @Zsailer
 
@@ -34,12 +34,12 @@ If you are joining the team video meeting, sign in below so we know who was here
 60 second updates on things you have been up to, questions you have, or developments you think people should know about. Please add yourself, and if you do not have an update to share, you can pass.
 
 - Hamel: [repo2docker GitHub Action](https://github.com/machine-learning-apps/repo2docker-action), allows you to dockerize your projects and cache them for Binder from GitHub!
-- We had a bunch of Binder usage over the last two weeks - first from SciPy and then from [PyHEP 2020](https://indico.cern.ch/event/882824/). Both have gone pretty smoothly, but brought up some questions about our process around catering to specific events. Can find a PR and several links to issues here: https://github.com/jupyterhub/mybinder.org-deploy/pull/1524
+- We had a bunch of Binder usage over the last two weeks - first from SciPy and then from [PyHEP 2020](https://indico.cern.ch/event/882824/). Both have gone pretty smoothly, but brought up some questions about our process around catering to specific events. Can find a PR and several links to issues here: <https://github.com/jupyterhub/mybinder.org-deploy/pull/1524>
 - Chris is going on paternity leave soon-ish. The babypocalypse is nigh! Expect him to be totally unreliable roughly mid-August through September (Chris promises to keep approving Numfocus payments for our Contributor in Residence :-) )
-- Chris has been working to launch a new non-profit with some others in the community. It's called 2i2c (https://2i2c.org/) and is just getting started. It will try to find a way to sustainably offer jupyterhub environments to research and education organizations, and provide support for our repositories / communities as well.
+- Chris has been working to launch a new non-profit with some others in the community. It's called 2i2c (<https://2i2c.org/>) and is just getting started. It will try to find a way to sustainably offer jupyterhub environments to research and education organizations, and provide support for our repositories / communities as well.
 - Steve: Jupyter Server migration
-  - https://github.com/jupyterhub/jupyterhub/issues/2984
-  - https://github.com/jupyterhub/jupyterhub/pull/2601
+  - <https://github.com/jupyterhub/jupyterhub/issues/2984>
+  - <https://github.com/jupyterhub/jupyterhub/pull/2601>
 - Erik: long battle with a [reliability issue with Z2JH's automatic TLS certificate acquisition](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1716)
 
 ## Reports and celebrations
@@ -60,7 +60,7 @@ Let's collect all potential agenda items here before the start of the meeting. W
     - contributing guide, COC, license, etc
   - people liked the idea of having it migrated to the JupyterHub org
   - conversation will continue in the issue
-- Chris Holdgraf (10 min): Moving Thebelab to the jupyterhub org [#313](https://github.com/jupyterhub/team-compass/issues/313) https://github.com/minrk/thebelab/issues/214
+- Chris Holdgraf (10 min): Moving Thebelab to the jupyterhub org [#313](https://github.com/jupyterhub/team-compass/issues/313) <https://github.com/minrk/thebelab/issues/214>
   - used to take a HTML page and hook it up to a kernel running on a JupyterHub like mybinder.org
   - the tech stack for thebelab is more JS than Python/Kubernetes, does the Hub team have the skills to keep maintaining it?
   - not a huge amount of work to maintain
@@ -68,7 +68,7 @@ Let's collect all potential agenda items here before the start of the meeting. W
   - some outstanding PRs and Issues that would be nice to adopt
   - people liked the idea of having it migrated to the JupyterHub org but basically split down the middle on executablebooks vs jupyterhub
   - discussion continues in the issue linked at the top
-  - https://github.com/minrk/thebelab/issues/214
+  - <https://github.com/minrk/thebelab/issues/214>
 - Matthew (10min): Binder does [PyHEP](https://indico.cern.ch/event/882824/) - retrospective
   - we bumped the limits for two or three repositories each day of this week
   - how did it go? What went well, not so well, random?
@@ -80,7 +80,7 @@ Let's collect all potential agenda items here before the start of the meeting. W
     - probably not so much as the conference already provided zoom, slack, etc
   - **Matthew:** Standing offer from the PyHEP organizers for a Binder keynote at future PyHEPs. :)
 - Tim, 5min: Microsoft Quantum Computing people make good use of mybinder.org
-  - https://github.com/jupyterhub/mybinder.org-deploy/issues/1538
+  - <https://github.com/jupyterhub/mybinder.org-deploy/issues/1538>
   - the quantumkata repo shows up on my radar once in a while
   - should we use the request to bump resources as a way to ask for cloud credits/sponsorship on Azure?
   - we have several contacts and we should start having discussions with all of them
@@ -106,4 +106,4 @@ Let's collect all potential agenda items here before the start of the meeting. W
   - TODO: create an issue template to help make this process more repeatable and easier
   - What about de-adopting projects if it turns out to be a bad idea... / it goes stale?
     - maybe use badges or a note in the README to signal that a repo is in need of new maintainers
-  - check out https://repostatus.org
+  - check out <https://repostatus.org>

--- a/docs/monthly-meeting/2020-07-16.md
+++ b/docs/monthly-meeting/2020-07-16.md
@@ -1,0 +1,109 @@
+# JupyterHub and BinderHub Team Meeting - July
+
+- **Date:** Thursday 16th July, 2020
+- **Time:** 5pm UTC
+  - **Your timezone:** https://arewemeetingyet.com/UTC/2020-07-16/17:00/Hubs%20Team%20Meeting
+- **GitHub issue:** https://github.com/jupyterhub/team-compass/issues/308
+- **Calendar for future meetings:** https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html
+
+## Welcome to the Team Meeting
+
+Hello!
+
+If you are joining the team video meeting, sign in below so we know who was here. Roll call:
+
+- name / institution / GitHub handle
+- Min / Simula / @minrk
+- Sarah / Turing / @sgibson91
+- Hamel / GitHub / [@hamelsmu](https://www.github.com/hamelsmu)
+- Chris / Berkeley / @choldgraf
+- Matthew / Illinois & PyHEP / [@matthewfeickert](https://www.github.com/matthewfeickert)
+- Tim / Binder/ @betatim
+- Steve / AWS / @blink1073
+- Darian / Two Sigma / @afshin
+- Georgiana / CIR / @GeorgianaElena
+- Richard / Aalto / @rkdarst
+- Erik / Sundell Open Source / [@consideRatio](https://www.github.com/consideRatio)
+- Rollin / NERSC / @rcthomas
+- Michael / Code for Philly / [@machow](http://github.com/machow)
+- Simon Li / OME, University of Dundee / @manics
+- Zach Sailer / Jupyter Cal Poly / @Zsailer
+
+## Quick updates
+
+60 second updates on things you have been up to, questions you have, or developments you think people should know about. Please add yourself, and if you do not have an update to share, you can pass.
+
+- Hamel: [repo2docker GitHub Action](https://github.com/machine-learning-apps/repo2docker-action), allows you to dockerize your projects and cache them for Binder from GitHub!
+- We had a bunch of Binder usage over the last two weeks - first from SciPy and then from [PyHEP 2020](https://indico.cern.ch/event/882824/). Both have gone pretty smoothly, but brought up some questions about our process around catering to specific events. Can find a PR and several links to issues here: https://github.com/jupyterhub/mybinder.org-deploy/pull/1524
+- Chris is going on paternity leave soon-ish. The babypocalypse is nigh! Expect him to be totally unreliable roughly mid-August through September (Chris promises to keep approving Numfocus payments for our Contributor in Residence :-) )
+- Chris has been working to launch a new non-profit with some others in the community. It's called 2i2c (https://2i2c.org/) and is just getting started. It will try to find a way to sustainably offer jupyterhub environments to research and education organizations, and provide support for our repositories / communities as well.
+- Steve: Jupyter Server migration
+  - https://github.com/jupyterhub/jupyterhub/issues/2984
+  - https://github.com/jupyterhub/jupyterhub/pull/2601
+- Erik: long battle with a [reliability issue with Z2JH's automatic TLS certificate acquisition](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/1716)
+
+## Reports and celebrations
+
+This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
+
+- **Sarah:** mybinder.org federation is now upgraded in parallel by GitHub Actions! Thanks to Min for helping with the deploy and debug.
+  - Chris reverses this "thank you" back to Sarah for doing all of this great work!
+- **Chris:** many thanks to Carol and Tim for helping debug what was going on with the xarray tutorial during SciPy!
+
+## Agenda items
+
+Let's collect all potential agenda items here before the start of the meeting. We will then attempt to create a coherent agenda that fits in the 60m meeting slot. If there are similar items try and group them together.
+
+- Hamel Husain (10 min): Proposal to include the repo2docker Action in the Jupyter org: [issue](https://github.com/jupyterhub/team-compass/issues/315#issuecomment-659003662)
+  - Tim can move the repo in terms of permissions
+  - check if there are paperwork issues to do first
+    - contributing guide, COC, license, etc
+  - people liked the idea of having it migrated to the JupyterHub org
+  - conversation will continue in the issue
+- Chris Holdgraf (10 min): Moving Thebelab to the jupyterhub org [#313](https://github.com/jupyterhub/team-compass/issues/313) https://github.com/minrk/thebelab/issues/214
+  - used to take a HTML page and hook it up to a kernel running on a JupyterHub like mybinder.org
+  - the tech stack for thebelab is more JS than Python/Kubernetes, does the Hub team have the skills to keep maintaining it?
+  - not a huge amount of work to maintain
+  - biggest source of "work" is keeping up with Jupyter Lab updates
+  - some outstanding PRs and Issues that would be nice to adopt
+  - people liked the idea of having it migrated to the JupyterHub org but basically split down the middle on executablebooks vs jupyterhub
+  - discussion continues in the issue linked at the top
+  - https://github.com/minrk/thebelab/issues/214
+- Matthew (10min): Binder does [PyHEP](https://indico.cern.ch/event/882824/) - retrospective
+  - we bumped the limits for two or three repositories each day of this week
+  - how did it go? What went well, not so well, random?
+  - Feedback: it was hard to convey to the authors of talks what binder is and why they need to prepare links more than 5min before the talk (**Matthew:** I'll note that this wasn't really any problem with Binder or the way that the docs are - they're great!. This was more just getting people to _read_, which I'm unqualified to offer solutions for.)
+  - Q: What did the audience think/say about having a binder?
+    - People asked interesting questions based on being able to run the code
+    - takes a moment for people to warm up to the idea, kept telling them to give it a go (**Matthew:** People seem excited and happy to use it once they've done so. More just that when you have 1000 people that are connecting for different portions you need to repeat everything again and again for the first 3 days.)
+  - Q: did people use the video links provided in a binder?
+    - probably not so much as the conference already provided zoom, slack, etc
+  - **Matthew:** Standing offer from the PyHEP organizers for a Binder keynote at future PyHEPs. :)
+- Tim, 5min: Microsoft Quantum Computing people make good use of mybinder.org
+  - https://github.com/jupyterhub/mybinder.org-deploy/issues/1538
+  - the quantumkata repo shows up on my radar once in a while
+  - should we use the request to bump resources as a way to ask for cloud credits/sponsorship on Azure?
+  - we have several contacts and we should start having discussions with all of them
+- Min (5 min): JupyterCon proposals are due on Monday — [CFP link](https://jupytercon.com/talk-poster-cfp/), [discussion issue](https://github.com/jupyterhub/team-compass/issues/312)
+  - there might be talks from core projects already w/o proposals, but check with Jason Grout
+- Rollin (5 min): Does anyone run Prometheus+Grafana as part of their hub deployment with Grafana as a JupyterHub service (admin access only) and are there any potential gotchas (I have a test deployment...)
+  - **rkdarst:** I do as part of my k8s hub, but I haven't thought about it much and am interested in practices.  I have an extra service that exports more data, and runs a periodic test job [link](https://github.com/AaltoSciComp/jupyterhub-aalto/blob/master/scripts/hub_status_service.py) - it's very hackish.
+    - **Erik:** (k8s) Yepp. Admin access only is not integrated with JupyterHub authentication or similar atm though, but simply as a pre-created admin user.
+      The configuration of this Helm chart that depends on the JupyterHub helm chart, Grafana Helm chart, and the Prometheus Helm chart, and follow a structure as required by the tool called `hubploy`.
+      - [neurohackademy/nh2020-jupyterhub](https://github.com/neurohackademy/nh2020-jupyterhub)
+      - [Relevant code 1](https://github.com/neurohackademy/nh2020-jupyterhub/blob/master/chart/values.yaml#L5-L14)
+      - [Relevant code 2](https://github.com/neurohackademy/nh2020-jupyterhub/blob/4d48154d34e0136a43a976080d7f295b94477556/chart/values.yaml#L62-L87)
+      - [Relevant code 3](https://github.com/neurohackademy/nh2020-jupyterhub/blob/4d48154d34e0136a43a976080d7f295b94477556/deployments/hub-neurohackademy-org/config/prod.yaml#L223-L244)
+  - AWESOME thanks!  Rollin will write something up and post it on discourse
+- At what point should things be offered for adoption by the jupyterhub organization?
+  - Balance: increased visibility vs increased team maintenance burden
+  - Are the people of JupyterHub interested in maintaining it?
+  - Considerations for issue template:
+    - are the people who created the project coming along to continue maintaining it?
+    - Documentation appropriate
+    - License
+    - Does it have good tests?
+  - TODO: create an issue template to help make this process more repeatable and easier
+  - What about de-adopting projects if it turns out to be a bad idea... / it goes stale?
+    - maybe use badges or a note in the README to signal that a repo is in need of new maintainers
+  - check out https://repostatus.org

--- a/docs/monthly-meeting/monthly_report_index.rst
+++ b/docs/monthly-meeting/monthly_report_index.rst
@@ -13,6 +13,7 @@ To generate the agenda for a new meeting, see the `Monthly Meeting Agenda Templa
    :maxdepth: 1
    :caption: Monthly reports
 
+   July 2020 <2020-07-16.md>
    June 2020 <2020-06-18.md>
    May 2020 <2020-05-21.md>
    April 2020 <2020-04-16.md>

--- a/docs/monthly-meeting/monthly_report_index.rst
+++ b/docs/monthly-meeting/monthly_report_index.rst
@@ -3,7 +3,7 @@
 Monthly Reports Archive
 =======================
 
-`Current Agenda <https://hackmd.io/MYNgpgHATAZgrAIwLQAYCMwAsTNhRJAThBQGYkoATEw0gQxgkroHYg==?view>`_
+`Current Agenda <https://hackmd.io/@sgibson91/hubs-team-meeting>`_
 
 Reports in reverse chronological order.
 

--- a/docs/weekly-reports/weekly_report_index.rst
+++ b/docs/weekly-reports/weekly_report_index.rst
@@ -3,7 +3,9 @@
 Weekly Reports Archive
 ======================
 
-`Current Agenda <https://hackmd.io/MYNgpgHATAZgrAIwLQAYCMwAsTNhRJAThBQGYkoATEw0gQxgkroHYg==?view>`_
+.. note::
+   These weekly meetings are a deprecated practice. The Hubs teams (JupyterHub
+   and BinderHub) now meet on a monthly basis, see :ref:`monthly-archive`.
 
 Reports in reverse chronological order
 


### PR DESCRIPTION
This PR adds the minutes from the July team meeting and also addresses some points raised by @choldgraf in https://github.com/jupyterhub/team-compass/issues/308#issuecomment-659074261

fixes #308 