### PR TITLE
Add November 2020 Team Meeting minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,6 @@ via the following main channels:
 
 *Note: any member of the community is welcome to participate in any of the process around discussion, archiving, and planning team meetings. Participate in whatever way works for you! Input is welcome!*
 
-### Weekly Team Reports
-
-The currently-active team report [exists in a HackMD](https://hackmd.io/MYNgpgHATAZgrAIwLQAYCMwAsTNhRJAThBQGYkoATEw0gQxgkroHYg==?view). Each week, team reports
-are archived in the [weekly reports archive](http://jupyterhub-team-compass.readthedocs.io/en/latest/weekly-reports/weekly_report_index.html). Then, a new report is created with the [team report template](http://jupyterhub-team-compass.readthedocs.io/en/latest/weekly-reports/team-meeting.html).
-
-* [Current week team report](https://hackmd.io/MYNgpgHATAZgrAIwLQAYCMwAsTNhRJAThBQGYkoATEw0gQxgkroHYg==?view)
-* [Weekly report archive](https://github.com/jupyterhub/team-compass/tree/master/docs/weekly-reports)
-
-
 ### Team Meetings
 
 **The JupyterHub Team meetings occur on the 3rd Thursday of every month,
@@ -75,3 +66,13 @@ Here are some useful links:
 
 The list of "core" members of the JupyterHub and Binder projects can be found on
 [the team-compass website](https://jupyterhub-team-compass.readthedocs.io/en/latest/team.html).
+
+### Weekly Team Reports
+
+> :rotating_light: The weekly team reports have been deprecated in favour of the monthly team meeting :rotating_light:
+
+The currently-active team report [exists in a HackMD](https://hackmd.io/MYNgpgHATAZgrAIwLQAYCMwAsTNhRJAThBQGYkoATEw0gQxgkroHYg==?view). Each week, team reports
+are archived in the [weekly reports archive](http://jupyterhub-team-compass.readthedocs.io/en/latest/weekly-reports/weekly_report_index.html). Then, a new report is created with the [team report template](http://jupyterhub-team-compass.readthedocs.io/en/latest/weekly-reports/team-meeting.html).
+
+* [Current week team report](https://hackmd.io/MYNgpgHATAZgrAIwLQAYCMwAsTNhRJAThBQGYkoATEw0gQxgkroHYg==?view)
+* [Weekly report archive](https://github.com/jupyterhub/team-compass/tree/master/docs/weekly-reports)

--- a/docs/monthly-meeting/2020-11-19.md
+++ b/docs/monthly-meeting/2020-11-19.md
@@ -1,0 +1,70 @@
+# JupyterHub and BinderHub Team Meeting - November
+
+- **Date:** Thursday 19th November 2020
+- **Time:** 5 PM UTC
+  - **Your timezone:** <https://arewemeetingyet.com/UTC/2020-11-19/17:00/Hubs-Team-Meeting>
+- **GitHub issue:** <https://github.com/jupyterhub/team-compass/issues/346>
+- **Calendar for future meetings:** <https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html>
+
+## Welcome to the Team Meeting
+
+Hello!
+
+If you are joining the team video meeting, sign in below so we know who was here. Roll call:
+
+- Tim / Binder / @betatim
+- Alex / Treebeard / @alex-treebeard (just want to learn/observe)
+- Sarah / Alan Turing Institute / @sgibson91
+- Simon / OME, University of Dundee / @manics
+- David / Software Heritage / @douardda
+- Mridul / GESIS / @MridulS
+- Rollin / NERSC / @rcthomas
+- Min / Simula / @minrk
+- Richard / Aalto University / @rkdarst
+
+## Quick updates
+
+60 second updates on things you have been up to, questions you have, or developments you think people should know about. Please add yourself, and if you do not have an update to share, you can pass.
+
+- **Sarah:** 2/4 of the Federation clusters are now running Helm 3! <https://github.com/jupyterhub/mybinder.org-deploy/issues/1542#issuecomment-714344364>
+- **Chris:** 2i2c exists!! <https://2i2c.org/posts/hello-world/>
+  - we will also announce some seed funding soon as well. this funding will pay for me and for georgiana!
+  - we will soon open a position for an "open source infrastructure engineer" to work on the pangeo project. if you or anyone you know is interested, please share! here is a draft of the job post <https://deploy-preview-28--cocky-booth-e7ed17.netlify.app/job/osie-pangeo/>
+
+## Reports and celebrations
+
+This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
+
+- Erik is a force of nature when it comes to switching to GitHub Actions!
+
+## Agenda items
+
+Let's collect all potential agenda items here before the start of the meeting. We will then attempt to create a coherent agenda that fits in the 60m meeting slot. If there are similar items try and group them together.
+
+- **Tim** [10minutes]: Use calver and cron job to release repo2docker once a month
+  - what do people think of tagging a release of repo2docker every month using a cron job in github actions? Using something like calver (for example v2020-11 for the November 2020 release) to assign a version to it. Using a cron job feels a bit "radical" but it would solve demand from the community for regular releases and automate our current recommendation of "you should be able to use `master`".
+  - People want to be able to `pip install jupyter-repo2docker` so we need to release to PyPI, not just tag in GitHub.
+  - If there was a way to make it easy for people to "install master" while doing `pip install` Tim would favour that but no one knows how to do that.
+  - dask calver discussion: <https://github.com/dask/community/issues/100>
+  - Should we also do this for BinderHub?
+    - potentially more tricky because we need to fit into SemVer syntax for our helm chart versions
+    - It is not required that the helm chart version matches the software version. Tim's impression is that most helm charts actively try to make the chart and software version "very different" to avoid the impression that they are related.
+    - we already publish a helm chart on every merge into `master`
+    - Tim would not change anything about BinderHub for now.
+      - we have some work to do just to restore the old behaviour of publishing a chart for every `master` commit because Travis is out of business.
+      - **Simon:** I agree, repo2docker is much more widely installed than BinderHub, so let's focus on that first and deal with BinderHub later
+  - Issues asking for releases:
+    - <https://github.com/jupyterhub/repo2docker/issues/980>
+  - Issues discussing ideas for automating/procedure:
+    - <https://github.com/jupyterhub/binderhub/issues/1141>
+  - **Sarah:** There is a GitHub Action for publishing to PyPI too! <https://github.com/marketplace/actions/pypi-publish>
+  - **Tim:** no opposition, let's pick *a* CalVer version without discussing it too long because it seems to turn into a never ending discussion
+- **Simon** [5 mins]: Planning to transfer <https://github.com/manics/action-k3s-helm/> to jupyterhub organisation
+- FYI new additions to binder
+  - [Mercurial provider](https://github.com/jupyterhub/binderhub/pull/1162) (BinderHub PR, already added to repo2docker)
+  - [Software Heritage Identifiers (SWHID)](https://github.com/jupyterhub/binder/issues/219) (Proposed addition)
+    - Who uses SWH and how?: It's an open archive so there are many anonymous users. Online journals are beginning to ask submitters to make sure the software is present in SWH archive. HAL (French repo for scientific open-access papers) -> largest percentage of users come from this use case.
+- **Tim:** what about python kubernetes v12 API client?
+- should henchbot use the "gh-pages published as a webpage" version of the helm charts repo instead of raw github
+  - maybe run henchbot less often?
+  - only consider a "version" ready when it is at least 5min old

--- a/docs/monthly-meeting/monthly_report_index.rst
+++ b/docs/monthly-meeting/monthly_report_index.rst
@@ -13,6 +13,7 @@ To generate the agenda for a new meeting, see the `Monthly Meeting Agenda Templa
    :maxdepth: 1
    :caption: Monthly reports
 
+   November 2020 <2020-11-19.md>
    October 2020 <2020-10-22.md>
    September 2020 <2020-09-17.md>
    August 2020 <2020-08-20.md>


### PR DESCRIPTION
this PR adds the minutes from the November 2020 team meeting to the repo. It also edits the README to note that weekly team reports have been deprecated.

fixes #346