### PR TITLE
Add HPC minutes

### DIFF
--- a/docs/meetings.rst
+++ b/docs/meetings.rst
@@ -23,6 +23,7 @@ for information on how to join.
    :caption: Team meetings
 
    monthly-meeting/monthly_report_index
+   monthly-meeting-hpc/monthly_report_index
 
 The JupyterHub team also used to keep weekly reports for what they had
 been up to. We recently switched to Monthly sync-ups instead of weekly

--- a/docs/monthly-meeting-hpc/2020-11-04.md
+++ b/docs/monthly-meeting-hpc/2020-11-04.md
@@ -1,0 +1,72 @@
+# JupyterHub HPC Meeting - November
+
+- **Date:** 2020-11-04
+- **Time:** 8:30 AM PST
+  - **Your timezone:** https://arewemeetingyet.com/Los%20Angeles/2020-11-04/08:30/JupyterHub-HPC
+- **GitHub issue:**
+- **Calendar for future meetings:** https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html
+
+## Welcome to the Meeting
+
+Hello! If you are joining the team video meeting, sign in below so we know who was here. Roll call:
+
+- **name** / **institution** / **GitHub handle**
+- Rollin / NERSC / @rcthomas
+- Shreyas Cholia / NERSC|LBL / @shreddd
+- Zach Price / ORNL
+- Mike Milligan / MSI@UMN / @mbmilligan
+- Kevin Paul / NCAR / @kmpaul
+- Félix-Antoine Fortin / Compute Canada - Université Laval / @cmd-ntrf
+- Jeffrey Miller / ORNL / @millerjl1701
+- Ryan Prout / ORNL
+- Spencer Ward / ORNL
+
+## Quick updates
+
+60 second updates on things you have been up to, questions you have, or developments you think people should know about. This is also a chance to suggest a future presentation if you've got work currently in progress you might want to share. Please add yourself, and if you do not have an update to share, you can pass.
+
+- **Rollin:** Working on Shifter (Docker) image selection at Hub service, prototype working, could demo at a future meeting, targeting Dec for deployment
+- **Rollin:** Moving deployment from a Rancher 1 to Rancher 2 (k8s) deployment also targeting Dec for deployment, could talk about that also at future meeting
+- **Mike**: MSI is moving main cluster from Torque to SLURM, so work ongoing to convert and update our deployment
+    - Need help from Carol to set up pushing to PyPI
+    - Dummy release of batchspawner 1.0.1, using GH actions
+    - Work in progress (see below)
+- **Kevin**: We have a release of [Jupyter-Forward](https://jupyter-forward.readthedocs.io/en/latest/) which is serving as our alternative for not have sysadmin privileges on our JupyterHub. Curious to know what other HPCers think about tools like this.
+
+## Reports and celebrations
+
+This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
+
+- New release of [Jupyter-Forward](https://jupyter-forward.readthedocs.io/en/latest/)
+    - Command line tool from remote machine
+    - Bundles up setting up ssh tunnel etc
+    - Side-steps hub
+    - Launch command can be submission to queue
+    - Puts the responsibility of intentionally waiting for a resource with a lot of contention more clearly onto the user (instead of waiting at hub all day)
+    - What about expanding scope beyond JupyterLab (start other things with it) there are other tools for which there is no "hub" -- Félix
+- add item here
+- add item here
+
+## Agenda items
+
+Let's collect all potential agenda items here before the start of the meeting. We will then attempt to create a coherent agenda that fits in the 60m meeting slot. If there are similar items try and group them together.
+
+- **Shreyas, Michael, Rollin, et al (10-15 min?):** JupyterCon retrospective
+    - Enterprise deployments, a few HPC deployment talks, mostly known to us already
+    - Notebooker etc might contain a lot of useful or reusable patterns, things that might be worth deploying for users
+    - Xeus kernel, debuggers, but not a plan to mainline those into the standard kernels
+- **Zach (20-30 min?):** JupyterHub setups at ORNL
+    - JupyterHub is a "birthright"
+    - At ORNL JupyterHub gets deployed in various places upon request from researchers
+    - Pushing the idea of a central entrypoint for JupyterHub, use BatchSpawner, WrapSpawner, ProfileSpawner to see what resources there are
+    - Otherwise it's repeating the same process every time with every group from the ground up
+    - Need higher availability for a institution-wide solution, would probably start with a lower user count but would go up like deploying gitlab etc (but is the hub the HA problem actually, it isn't at at NERSC really...)
+    - Multiple security zones, LDAP instances that can't be used, makes things more challenging
+    - "ProfileSpawner" for Authenticators?  Is that a JupyterHub responsibility or some other solution (Dex oauth)?  JWT?
+- JupyterLab 3 + JupyterHub - does anyone know if the integration works? - Shreyas
+    - Rollin says no (haven't tried to run off master but that may make it work)
+- **Mike** - trying to debug Github Actions pipeline for pushing batchspawner/wrapspawner releases to PyPI
+    - Fixed a bug during the meeting
+- **Rollin** - Fake batch spawner in BatchSpawner so I don't have to handle sshspawner separately, which needs a bunch of the same logic?
+    - What about systemd (Zach)?
+- add item here (include your name and estimated time for discussion).

--- a/docs/monthly-meeting-hpc/2020-12-02.md
+++ b/docs/monthly-meeting-hpc/2020-12-02.md
@@ -1,0 +1,61 @@
+# JupyterHub HPC Meeting - December
+
+- **Date:** 2020-12-02
+- **Time:** 8:30 AM PST
+  - **Your timezone:** https://arewemeetingyet.com/Los%20Angeles/2020-12-02/08:30/JupyterHub-HPC
+- **GitHub issue:**
+- **Calendar for future meetings:** https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html
+
+## Welcome to the Meeting
+
+Hello! If you are joining the team video meeting, sign in below so we know who was here. Roll call:
+
+- **name** / **institution** / **GitHub handle**
+- Rollin / NERSC / @rcthomas
+- Kevin / NCAR / @kmpaul
+- Félix-Antoine / Université Laval, Compute Canada / @cmd-ntrf
+- Jeffrey / ORNL / @millerjl1701
+- Zach Price / ORNL
+- Richard Drast / Aalto / @rkdarst
+- Michael Milligan / MSI@UMN / @mbmilligan
+- Shane / NERSC / @scanon
+
+## Quick updates
+
+60 second updates on things you have been up to, questions you have, or developments you think people should know about. This is also a chance to suggest a future presentation if you've got work currently in progress you might want to share. Please add yourself, and if you do not have an update to share, you can pass.
+
+- **NAME:** What you'd like to update on
+- **Rollin:** Notes from last meeting on team-compass, PR/issue
+- **Kevin:** Hit another sysadmin blocking issue at NCAR, does anyone have interest in setting up a "mock HPC system" on AWS or GCP or otherwise for dev/testing of JupyterHub-based services?  (e.g., Binder for HPC and more)  If yes, then we can discuss below.
+  - For another local test, I [name=rkdarst] used https://github.com/giovtorres/docker-centos7-slurm (also https://github.com/giovtorres/slurm-docker-cluster for multi-container)
+  - +1
+  - For more elaborate setup, have a look at Magic Castle: https://github.com/computecanada/magic_castle which can setup a Slurm cluster + JupyterHub in AWS, Azure, GCP and OpenStack
+- **Félix-Antoine:** Where are we with batchspawner PR #187 - https://github.com/jupyterhub/batchspawner/pull/187 ?
+- **Michael:** Worked out the kinks in the CI for batchspawner, and there's a release out on PyPI.  Never had a wrapspawner release on PyPI but Michael is look at getting that out on PyPI (make sure no issues, `setup.py` works etc)
+    - Richard: Made an action to check tag against version in the package to make sure they are the same.  Seems like a common need, useful in his case.
+
+## Reports and celebrations
+
+This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
+
+- add item here
+- add item here
+
+## Agenda items
+
+Let's collect all potential agenda items here before the start of the meeting. We will then attempt to create a coherent agenda that fits in the 60m meeting slot. If there are similar items try and group them together.
+
+- **Multi:** PR 187
+    - Any objection to get this merged and out?
+    - No.  Original PR was handling the unknown job state etc
+    - Some places are already running the original branch
+    - Question about whether unknown state should be in JupyterHub: No, see https://github.com/jupyterhub/jupyterhub/issues/3171
+    - Looks like it's OK to merge...
+    - How soon to do a release?
+        - Merge (done now), give people a week to bang on it
+        - Make RC release, another week
+        - Thumbs up next month then make release
+- **Rollin:**
+    - Talks about wrapspawner #41, will work on it
+        - https://github.com/jupyterhub/wrapspawner/issues/41
+        - Traitlets expert who can help if it turns out to be that?

--- a/docs/monthly-meeting-hpc/monthly_report_index.rst
+++ b/docs/monthly-meeting-hpc/monthly_report_index.rst
@@ -1,0 +1,15 @@
+.. _monthly-archive:
+
+Monthly Reports Archive (HPC)
+=============================
+
+Reports in reverse chronological order.
+
+To generate the agenda for a new meeting, see the `Monthly Meeting Agenda Template <https://raw.githubusercontent.com/jupyterhub/team-compass/master/docs/monthly-meeting/monthly-meeting-template.md>`_.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Monthly reports
+
+   November 2020 <2020-11-04.md>
+   Monthly meeting template <https://raw.githubusercontent.com/jupyterhub/team-compass/master/docs/monthly-meeting/monthly-meeting-template.md>


### PR DESCRIPTION
Adds a directory called `docs/monthly-meeting-hpc`, adds the November HPC meeting to that directory.  No index is added here yet and no attempt is yet made to integrate the docs with the rest of the site.  As mentioned in #352 the initial goal is to formalize the agenda and surface the notes in a central place.  If there are suggestions about how to integrate the notes in the generated site I could work on that.