### PR TITLE
Add Code of Conduct to repo and monthly meeting template

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Most of the Team Compass lives in this website:
 
 * [The JupyterHub Team Compass](http://jupyterhub-team-compass.readthedocs.io/)
 
+Please familiarise yourself with the [Code of Conduct](https://jupyter.org/conduct/).
 
 ## Team information
 

--- a/docs/monthly-meeting/monthly-meeting-template.md
+++ b/docs/monthly-meeting/monthly-meeting-template.md
@@ -12,6 +12,8 @@ tags: binder, meeting, notes
 - **GitHub issue:**
 - **Calendar for future meetings:** https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings.html
 
+#### By participating in this meeting, you are agreeing to abide by and uphold the [Code of Conduct](https://jupyter.org/conduct). Please take a second to read through it! :pray:
+
 ## Welcome to the Team Meeting
 
 Hello!


### PR DESCRIPTION
This PR adds links to the Jupyter Code of Conduct in the repo's readme and the template for the monthly meeting.

related #361