### PR TITLE
Update Sarah's affiliation on team page

### DIFF
--- a/docs/team/contributors-jupyterhub.yaml
+++ b/docs/team/contributors-jupyterhub.yaml
@@ -25,10 +25,10 @@
 
 - name: Sarah Gibson
   handle: "@sgibson91"
-  affiliation: The Alan Turing Institute
+  affiliation: 2i2c
   contributions: question,doc,tutorial,infra,talk,test
   team: red
-  focus: binder
+  focus: jupyterhub, binder
   last-check-in: 2019-10
 
 - name: Tim Head


### PR DESCRIPTION
Just keeping my info on the team page up-to-date :) I suspect I will start to get more involved with JupyterHub things as work at 2i2c ramps up