### PR TITLE
Add shared infrastructure and add communications to team guide

### DIFF
--- a/docs/index-team_governance.rst
+++ b/docs/index-team_governance.rst
@@ -8,7 +8,6 @@ Project planning, decision-making, etc
 
 .. toctree::
 
-   team/adding-members
    governance
    binder/governance
    binder/subdomains

--- a/docs/index-team_guides.rst
+++ b/docs/index-team_guides.rst
@@ -10,4 +10,6 @@ Guides for JupyterHub teams
 
    team/member-guide
    team/skills
+   team/adding-members
+   team/shared-infrastructure
    talking

--- a/docs/team/adding-members.rst
+++ b/docs/team/adding-members.rst
@@ -61,7 +61,6 @@ issue and the team member is now ready to go!
    - [ ] A gmail account (for GKE credentials + Google team drive)
    - [ ] A [PyPI account](https://pypi.org) (for PyPI access)
    - [ ] A [Discourse account](https://discourse.jupyter.org)
-   - [ ] A [Quay.io account](https://quay.io/)
    
    **Membership**
    

--- a/docs/team/adding-members.rst
+++ b/docs/team/adding-members.rst
@@ -74,7 +74,6 @@ issue and the team member is now ready to go!
          (binder-prod, binder-staging, binder-sandbox)
    - [ ] Add them as collaborators on the repo2docker and BinderHub PyPI packages
    - [ ] Add them to the [jupyterhub team google drive](https://drive.google.com/drive/folders/0B8VZ4vaOYWZ3a2dyeEp6NzBKbnM?usp=sharing)
-   - [ ] Add them to [our Quay.io Image Registry](https://quay.io/organization/jupyterhub)).
 
    **Learning**
    

--- a/docs/team/adding-members.rst
+++ b/docs/team/adding-members.rst
@@ -61,6 +61,7 @@ issue and the team member is now ready to go!
    - [ ] A gmail account (for GKE credentials + Google team drive)
    - [ ] A [PyPI account](https://pypi.org) (for PyPI access)
    - [ ] A [Discourse account](https://discourse.jupyter.org)
+   - [ ] A [Quay.io account](https://quay.io/)
    
    **Membership**
    
@@ -74,7 +75,8 @@ issue and the team member is now ready to go!
          (binder-prod, binder-staging, binder-sandbox)
    - [ ] Add them as collaborators on the repo2docker and BinderHub PyPI packages
    - [ ] Add them to the [jupyterhub team google drive](https://drive.google.com/drive/folders/0B8VZ4vaOYWZ3a2dyeEp6NzBKbnM?usp=sharing)
-   
+   - [ ] Add them to [our Quay.io Image Registry](https://quay.io/organization/jupyterhub)).
+
    **Learning**
    
    - [ ] Send them [a short onboarding message](https://jupyterhub-team-compass.readthedocs.io/team/adding-members.html#an-official-onboarding-message)

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -106,6 +106,15 @@ a few things that you should do as a new team member:
    If it's something you'd rather not mention to the public then
    send an email to one of the team members letting them know, and they
    can communicate it to the others.
+6. **Foster open and inclusive discussion**. As a team member, you are
+   responsible for ensuring that conversation in our communities is positive
+   and inclusive. Open public issues to discuss things with the team. Try to
+   do most communication in public spaces where others can join, or
+   report back to team members if important conversations happened offline.
+   When creating issues, provide enough context so that others can understand
+   and provide their input. Encourage feedback and input from others
+   often, and be patient when merging code - it is almost better to
+   wait a bit for an approve than to self-merge.
 
 ## When should I merge a pull request?
 

--- a/docs/team/shared-infrastructure.md
+++ b/docs/team/shared-infrastructure.md
@@ -12,7 +12,7 @@ This organization is where we do most of the code-related work for the project, 
 
 We have [a quay.io organization](https://quay.io/organization/jupyterhub) for hosting Docker images.
 This is used to push new images for tools like BinderHub and JupyterHub for Kubernetes.
-If you do not have access to this organization, ask a team member to add you.
+If you do not have access to this organization and require it, ask a team member to add you.
 
 ## Image registry on Dockerhub
 

--- a/docs/team/shared-infrastructure.md
+++ b/docs/team/shared-infrastructure.md
@@ -11,14 +11,13 @@ This organization is where we do most of the code-related work for the project, 
 ## Image registry on quay.io
 
 We have [a quay.io organization](https://quay.io/organization/jupyterhub) for hosting Docker images.
-This is used to push new images for tools like BinderHub and JupyterHub for Kubernetes.
+This is used for the repo2docker base image.
 If you do not have access to this organization and require it, ask a team member to add you.
 
 ## Image registry on Dockerhub
 
 We have [a DockerHub organization](https://hub.docker.com/r/jupyterhub/jupyterhub/) for hosting Docker images.
-This was used more heavily in the past, but due to recent DockerHub pricing changes it is no longer a sustainable option.
-However, we're listing it here since some of our images are still hosted there.
+BinderHub and JupyterHub images are pushed to DockerHub as that still works, though we are considering publishing these images to use quay.io as well.
 
 ## Google Cloud Project
 

--- a/docs/team/shared-infrastructure.md
+++ b/docs/team/shared-infrastructure.md
@@ -14,7 +14,7 @@ We have [a quay.io organization](https://quay.io/organization/jupyterhub) for ho
 This is used for the repo2docker base image.
 If you do not have access to this organization and require it, ask a team member to add you.
 
-## Image registry on Dockerhub
+## Image registry on DockerHub
 
 We have [a DockerHub organization](https://hub.docker.com/r/jupyterhub/jupyterhub/) for hosting Docker images.
 BinderHub and JupyterHub images are pushed to DockerHub as that still works, though we are considering publishing these images to use quay.io as well.

--- a/docs/team/shared-infrastructure.md
+++ b/docs/team/shared-infrastructure.md
@@ -18,6 +18,7 @@ If you do not have access to this organization and require it, ask a team member
 
 We have [a DockerHub organization](https://hub.docker.com/r/jupyterhub/jupyterhub/) for hosting Docker images.
 BinderHub and JupyterHub images are pushed to DockerHub as that still works, though we are considering publishing these images to use quay.io as well.
+If you do not have access to this organization and require it, ask a team member to add you.
 
 ## Google Cloud Project
 

--- a/docs/team/shared-infrastructure.md
+++ b/docs/team/shared-infrastructure.md
@@ -1,0 +1,27 @@
+# Our Shared Infrastructure
+
+There are a few services and infrastructure that the JupyterHub team has access to.
+Some of these are useful for our development workflows, while others are used as a part of services that we run.
+
+## GitHub
+
+We have [a GitHub organization](https://github.com/jupyterhub/) for hosting all of our code repositories.
+This organization is where we do most of the code-related work for the project, and where we have discussions and coordination.
+
+## Image registry on quay.io
+
+We have [a quay.io organization](https://quay.io/organization/jupyterhub) for hosting Docker images.
+This is used to push new images for tools like BinderHub and JupyterHub for Kubernetes.
+If you do not have access to this organization, ask a team member to add you.
+
+## Image registry on Dockerhub
+
+We have [a DockerHub organization](https://hub.docker.com/r/jupyterhub/jupyterhub/) for hosting Docker images.
+This was used more heavily in the past, but due to recent DockerHub pricing changes it is no longer a sustainable option.
+However, we're listing it here since some of our images are still hosted there.
+
+## Google Cloud Project
+
+The Binder Team uses a Google Cloud Project called `binderhub`.
+This project runs the BinderHub deployment that is found at `gke.mybinder.org`.
+The project is currently funded from a grant from Google.


### PR DESCRIPTION
This is a couple of small additions to the Team Compass after recent conversations in the team meeting. It does the following main things:

1. Adds mention of `quay.io` to our onboarding instructions
2. Adds a "shared infrastructure" page and lists a few major pieces of shared infrastructure I could think of (including quay.io)
3. Adds a paragraph to the Team Guide about fostering open communication (and I think this closes https://github.com/jupyterhub/binderhub/issues/178)
4. Also moves the "adding members" (onboarding guide) to our "team guides" rather than "governance"