### PR TITLE
Fixed link to All Contributors project

### DIFF
--- a/docs/team.rst
+++ b/docs/team.rst
@@ -54,7 +54,7 @@ Emoji keys
 ----------
 
 You may notice that some of the team-members have "emojis" to reflect their
-contributions in JupyterHub. These are from the `Kent Dodds "all contributors spec" <LINK>`_.
+contributions in JupyterHub. These are from the `Kent Dodds "all contributors spec" <https://allcontributors.org/>`_.
 Below is a short table to show what each emoji represents.
 
 .. csv-table::


### PR DESCRIPTION
Hi there. I was browsing your website and found this empty link. I guess that's what you meant!
Other possible links are:
- https://github.com/all-contributors/all-contributors
- https://allcontributors.org/docs/en/emoji-key