### PR TITLE
Update information about mybinder.org ownership

### DIFF
--- a/docs/team/shared-infrastructure.md
+++ b/docs/team/shared-infrastructure.md
@@ -1,4 +1,4 @@
-# Our Shared Infrastructure
+# Shared accounts and infrastructure
 
 There are a few services and infrastructure that the JupyterHub team has access to.
 Some of these are useful for our development workflows, while others are used as a part of services that we run.

--- a/docs/team/shared-infrastructure.md
+++ b/docs/team/shared-infrastructure.md
@@ -40,11 +40,11 @@ However, it is unclear what is the best way to do this right now, and so we are 
 The DNS for `mybinder.org` is handled by [CloudFlare](https://www.cloudflare.com/), by a central Jupyter account.
 
 (shared:gcp)=
-### Google Cloud Project
+### Google Cloud Platform (GCP) Project
 
-The Binder Team uses a Google Cloud Project called `binderhub`.
-This project runs the BinderHub deployment that is found at `gke.mybinder.org`.
-The project is currently funded from a grant from Google.
+The Binder Team uses a GCP project with id [`binderhub-288415`](https://console.cloud.google.com/home/dashboard?project=binderhub-288415) to host `gke.mybinder.org` and top level federation services at `mybinder.org`. The `binderhub-288415` GCP project resides in the GCP organization [`jupyter.org`](https://console.cloud.google.com/iam-admin/iam?organizationId=920697752286).
+
+The `binderhub-288415` GCP project is currently funded by a grant from Google, as represented as GCP credits. The credits belong to billing account belonging to the GCP organization `jupyter.org`, as can be seen [under its billing section](https://console.cloud.google.com/billing?organizationId=920697752286).
 
 ### Other cloud deployments in the federation
 

--- a/docs/team/shared-infrastructure.md
+++ b/docs/team/shared-infrastructure.md
@@ -20,8 +20,33 @@ We have [a DockerHub organization](https://hub.docker.com/r/jupyterhub/jupyterhu
 BinderHub and JupyterHub images are pushed to DockerHub as that still works, though we are considering publishing these images to use quay.io as well.
 If you do not have access to this organization and require it, ask a team member to add you.
 
-## Google Cloud Project
+## `mybinder.org` infrastructure
+
+The `mybinder.org` service has a few pieces related to the domain that are described below:
+
+### Ownership of the `mybinder.org` domain
+
+The `mybinder.org` domain is owned by Chris Holdgraf ([@choldgraf](https://github.com/choldgraf)).
+The registrar for this domain is [BlueHost](https://bluehost.com).
+The email address with contact information for the domain is `binder-team@googlegroups.com`.
+
+```{admonition} TODO
+In the future we wish to transfer ownership of this domain away from Chris's personal account.
+However, it is unclear what is the best way to do this right now, and so we are waiting for clarification from the Jupyter project at-large about how the project itself can own mybinder.org instead of Chris.
+```
+
+### DNS entries for `mybinder.org`
+
+The DNS for `mybinder.org` is handled by [CloudFlare](https://www.cloudflare.com/), by a central Jupyter account.
+
+(shared:gcp)=
+### Google Cloud Project
 
 The Binder Team uses a Google Cloud Project called `binderhub`.
 This project runs the BinderHub deployment that is found at `gke.mybinder.org`.
 The project is currently funded from a grant from Google.
+
+### Other cloud deployments in the federation
+
+There are a number of other cloud deployments in the BinderHub federation, but these are not centrally managed by the Binder Team.
+Instead, they are managed by the individuals and organizations that represent each of the BinderHubs in the federation.

--- a/docs/team/shared-infrastructure.md
+++ b/docs/team/shared-infrastructure.md
@@ -32,7 +32,7 @@ The email address with contact information for the domain is `binder-team@google
 
 ```{admonition} TODO
 In the future we wish to transfer ownership of this domain away from Chris's personal account.
-However, it is unclear what is the best way to do this right now, and so we are waiting for clarification from the Jupyter project at-large about how the project itself can own mybinder.org instead of Chris.
+However, it is unclear what is the best way to do this right now, and so we are waiting for clarification from the Jupyter project at-large about how the project itself can own mybinder.org instead of Chris. We also plan to use a contact email for this domain that has fewer people on it than the entire team, but are using `binder-team@googlegroups.com` as a stop-gap measure for now to increase our bus factor.
 ```
 
 ### DNS entries for `mybinder.org`


### PR DESCRIPTION
This adds some information about the `mybinder.org` domain to our shared infrastructure page, to make it clearer who owns / controls what. It also notes that I am the current owner of `mybinder.org` and makes it clear that this is not what we want for a long-term solution!

I am still trying to switch the contact email for `mybinder.org`'s registration from my personal email to `binder-team@googlegroups.com`. But the confirmation doesn't seem to be coming through. Will follow up on that.

Long-term, we also discussed that we should probably use an email for mybinder.org that has fewer people on it than the entire Binder team, so that we can minimize potential security risks there (since that email can be used to confirm potentially damaging actions like changing that URL's DNS provider). But for now, I just switched the contact email to `binder-team@googlegroups.org` since we're also using that as a contact for other shared services like LetsEncrypt

part of #424 closes https://github.com/jupyterhub/team-compass/pull/470

### Tasks to complete

- [x] Confirm that `binder-team@googlegroups.com` is now the contact for the registrar
- [x] Get approval in this PR about the language