### PR TITLE
Add meetings index to main page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,6 @@ governance and planning.
    :maxdepth: 2
 
    team/index
-   meetings/index
    index-team_guides
    index-team_governance
    contribute/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ governance and planning.
    :maxdepth: 2
 
    team/index
+   meetings/index
    index-team_guides
    index-team_governance
    contribute/index

--- a/docs/team/index.rst
+++ b/docs/team/index.rst
@@ -10,7 +10,7 @@ For information about what these teams mean and how you can join, see :doc:`stru
 For more information about the team, see the sections to the left:
 
 .. toctree::
-   :hidden:
+   :maxdepth: 2
 
    structure
    ../meetings/index


### PR DESCRIPTION
At the moment there's no obvious link to the meetings
![image](https://user-images.githubusercontent.com/1644105/174147390-a17bb70f-775b-4c78-a30d-e1cb62dd6aee.png)
