### PR TITLE
Add a community strategy sub-page and provide a brief update on works so far

### DIFF
--- a/docs/index-team_guides.rst
+++ b/docs/index-team_guides.rst
@@ -14,3 +14,4 @@ Resources and guides for team members to help us coordinate and work together mo
    team/shared-infrastructure
    talking
    building-blocks/index
+   team/community-strategy

--- a/docs/team/community-strategy.md
+++ b/docs/team/community-strategy.md
@@ -21,4 +21,4 @@ We have funding to support four Outreachy interns per year (two per cohort, and 
 
 The next round of Outreachy interns will be placed between December, 2022 and March, 2023 and I have been organising mentors and projects to be involved with this round.
 I am participating as a mentor in this round to **learn** about requirements and barriers for JupyterHub members to participate in organising such mentorship-based approaches into the community.
-I will then generate some documentation based on my learnings and move to an "overseer" role for future cohorts.
+I will then generate some documentation based on my learnings, as well as pulling from the groundbreaking work of the Open Life Science team, and move to an "overseer" role for future cohorts.

--- a/docs/team/community-strategy.md
+++ b/docs/team/community-strategy.md
@@ -14,7 +14,7 @@ Additionally, you can find information on other related activities via the [![cs
 
 ## Community Strategy Updates
 
-### 2022-10-07: 2 month strategy so far
+### 2022-09-07: 2 month strategy so far
 
 One strategy is to develop onboarding pathways through Outreachy,then into Contributor in Residence, and finally as a fully-fledged community member.
 We have funding to support four Outreachy interns per year (two per cohort, and cohorts happen twice per year) and "promote" one of the four from Y1 into CIR for Y2.

--- a/docs/team/community-strategy.md
+++ b/docs/team/community-strategy.md
@@ -3,7 +3,7 @@
 This page contains information regarding activities undertaken and community strategies developed by the Community Strategic Lead.
 [Sarah Gibson](https://github.com/sgibson91) is currently serving in this role as of August 2022, for a period of two years.
 
-This role and related activities are funded by a CZI EOSS DEI grant, administered by NumFOCUS.
+This role and related activities are funded by [a CZI EOSS DEI grant](https://drive.google.com/file/d/124LWcFe8Hq2n_3l4jAgDgJ1lpXRzV1Kc/view?usp=sharing), administered by [NumFOCUS](https://numfocus.org).
 
 ```{admonition} Work in Progress
 The work represented on this page is under active development and we will update information as soon as we are able to as we iterate.

--- a/docs/team/community-strategy.md
+++ b/docs/team/community-strategy.md
@@ -9,7 +9,8 @@ This role and related activities are funded by [a CZI EOSS DEI grant](https://dr
 The work represented on this page is under active development and we will update information as soon as we are able to as we iterate.
 ```
 
-Some information is being shared in [Issue #536](https://github.com/jupyterhub/team-compass/issues/536), which will be migrated here over time.
+<!-- Using a raw link here as a PyData Sphinx theme release will format them for us: https://pydata-sphinx-theme.readthedocs.io/en/latest/user_guide/theme-elements.html#link-shortening-for-git-repository-services -->
+Some information is being shared in https://github.com/jupyterhub/team-compass/issues/536, which will be migrated here over time.
 Additionally, you can find information on other related activities via the [![csl-label](https://img.shields.io/github/labels/jupyterhub/team-compass/community-strategic-lead)](https://github.com/jupyterhub/team-compass/issues?q=label%3Acommunity-strategic-lead) label.
 
 ## Community Strategy Updates

--- a/docs/team/community-strategy.md
+++ b/docs/team/community-strategy.md
@@ -1,0 +1,24 @@
+# Community Strategy
+
+This page contains information regarding activities undertaken and community strategies developed by the Community Strategic Lead.
+[Sarah Gibson](https://github.com/sgibson91) is currently serving in this role as of August 2022, for a period of two years.
+
+This role and related activities are funded by a CZI EOSS DEI grant, administered by NumFOCUS.
+
+```{admonition} Work in Progress
+The work represented on this page is under active development and we will update information as soon as we are able to as we iterate.
+```
+
+Some information is being shared in [Issue #536](https://github.com/jupyterhub/team-compass/issues/536), which will be migrated here over time.
+Additionally, you can find information on other related activities via the [![csl-label](https://img.shields.io/github/labels/jupyterhub/team-compass/community-strategic-lead)](https://github.com/jupyterhub/team-compass/issues?q=label%3Acommunity-strategic-lead) label.
+
+## Community Strategy Updates
+
+### 2022-10-07: 2 month strategy so far
+
+One strategy is to develop onboarding pathways through Outreachy,then into Contributor in Residence, and finally as a fully-fledged community member.
+We have funding to support four Outreachy interns per year (two per cohort, and cohorts happen twice per year) and "promote" one of the four from Y1 into CIR for Y2.
+
+The next round of Outreachy interns will be placed between December, 2022 and March, 2023 and I have been organising mentors and projects to be involved with this round.
+I am participating as a mentor in this round to **learn** about requirements and barriers for JupyterHub members to participate in organising such mentorship-based approaches into the community.
+I will then generate some documentation based on my learnings and move to an "overseer" role for future cohorts.

--- a/docs/team/community-strategy.md
+++ b/docs/team/community-strategy.md
@@ -17,7 +17,7 @@ Additionally, you can find information on other related activities via the [![cs
 
 ### 2022-09-07: 2 month strategy so far
 
-One strategy is to develop onboarding pathways through Outreachy,then into Contributor in Residence, and finally as a fully-fledged community member.
+One strategy is to develop onboarding pathways through Outreachy, then into Contributor in Residence, and finally as a fully-fledged community member.
 We have funding to support four Outreachy interns per year (two per cohort, and cohorts happen twice per year) and "promote" one of the four from Y1 into CIR for Y2.
 
 The next round of Outreachy interns will be placed between December, 2022 and March, 2023 and I have been organising mentors and projects to be involved with this round.


### PR DESCRIPTION
Adds a sub-page to our docs to gather information on the CSL role. Provides a brief update on thinkings/activities so far.

This is super bare bones to begin with. Happy to tweak format as needed.