### PR TITLE
Update team page with council membership list

### DIFF
--- a/docs/_data/contributors/contributors-jupyterhub.yaml
+++ b/docs/_data/contributors/contributors-jupyterhub.yaml
@@ -1,108 +1,123 @@
-# Use ALPHABETICAL ORDER please :-)
-- name: Matthias Busonnier
-  handle: "carreau"
-  affiliation: UC Merced
-  contributions: code,infra
-  status: active
-  last-check-in: 2019-10
+# teams:
+# - council: JupyterHub council
+# - maintainers:
+# - mybinder: mybinder.org operators
+# no team means inactive
 
+# Use ALPHABETICAL ORDER please :-)
 - name: Georgiana Dolocan
   handle: "GeorgianaElena"
-  affiliation: Simula
+  affiliation: 2i2c
   contributions: code
   focus: jupyterhub
-  status: active
-  last-check-in: 2019-10
-
-- name: Jessica Forde
-  handle: "jzf2101"
-  affiliation: UC Berkeley
-  contributions: doc
-  focus: jupyterhub, binder
-  status: active
-  last-check-in: 2019-10
+  teams:
+    - council
+  last-check-in: 2022-09
 
 - name: Sarah Gibson
   handle: "sgibson91"
   affiliation: 2i2c
   contributions: question,doc,tutorial,infra,talk,test
   focus: jupyterhub, binder
-  status: active
-  last-check-in: 2019-10
+  teams:
+    - council
+  last-check-in: 2022-09
 
 - name: Tim Head
   handle: "betatim"
   affiliation: Wild Tree Tech
   contributions: bizdev, code, fundingFinding, ideas, talk, infra
   focus: jupyterhub, binder
-  status: active
-  last-check-in: 2019-12
+  teams:
+    - council
+  last-check-in: 2022-09
 
 - name: Chris Holdgraf
   handle: "choldgraf"
   affiliation: 2i2c
   contributions: code,ideas,doc,question
   focus: jupyterhub, binder
-  status: active
-  last-check-in: 2019-10
+  teams:
+    - council
+  last-check-in: 2022-09
 
 - name: Simon Li
   handle: "manics"
   affiliation: Open Microscopy Environment, University of Dundee
   contributions: code,question
   focus: jupyterhub
-  status: active
-  last-check-in: 2019-11
-
-- name: M Pacer
-  handle: "mpacer"
-  affiliation: Netflix
-  contributions: ""
-  focus: binder
-  status: active
-  last-check-in: 2019-10
+  teams:
+    - council
+  last-check-in: 2022-09
 
 - name: Yuvi Panda
   handle: "yuvipanda"
   affiliation: UC Berkeley
   contributions: "code,infra"
   focus: jupyterhub
-  status: active
-  last-check-in: 2019-10
+  teams:
+    - council
+  last-check-in: 2022-09
 
 - name: Min Ragan-Kelley
   handle: "minrk"
   affiliation: Simula
   contributions: code,infra
   focus: jupyterhub, binder
-  status: active
-  last-check-in: 2019-10
+  teams:
+    - council
+  last-check-in: 2022-09
 
 - name: Erik Sundell
   handle: "consideRatio"
   affiliation: Sandvik CODE
   contributions: code,infra
   focus: jupyterhub, binder
-  status: active
-  last-check-in: 2019-10
+  teams:
+    - council
+  last-check-in: 2022-09
 
 - name: Carol Willing
   handle: "willingc"
   affiliation: Project Jupyter
   contributions: Python,Community
   focus: jupyterhub, binder
-  status: active
-  last-check-in: 2019-10
+  teams:
+    - council
+  last-check-in: 2022-09
 
 
-# Green team members at the end, also alphabetical
+# Inactive team members at the end, also alphabetical
+- name: Matthias Busonnier
+  handle: "carreau"
+  affiliation: UC Merced
+  contributions: code,infra
+  status: inactive
+  last-check-in: 2022-09
+
+- name: Jessica Forde
+  handle: "jzf2101"
+  affiliation: UC Berkeley
+  contributions: doc
+  focus: jupyterhub, binder
+  status: inactive
+  last-check-in: 2022-09
+
 - name: Lindsey Heagy
   handle: "lheagy"
   affiliation: UC Berkeley
   contributions: ideas,example
   focus: binder
   status: inactive
-  last-check-in: 2019-10
+  last-check-in: 2022-09
+
+- name: M Pacer
+  handle: "mpacer"
+  affiliation: Netflix
+  contributions: ""
+  focus: binder
+  status: inactive
+  last-check-in: 2022-09
 
 - name: Zach Sailer
   handle: "Zsailer"
@@ -110,4 +125,4 @@
   contributions: code,ideas,question
   focus: binder
   status: inactive
-  last-check-in: 2019-10
+  last-check-in: 2022-09


### PR DESCRIPTION
closes #566 

I added everyone who said at least 'maybe' for the Council, since we don't have too many (9), and folks can always step down.

Adds the team membership to each team member card. However, _all_ currently active team members are steering council members. I added some more todos in https://github.com/jupyterhub/team-compass/issues/497#issuecomment-1263532945 because we haven't updated the _other_ team lists, which still need updating. Including recognizing several folks who I think ought to be current 'team members' by the new definition but aren't listed right now.