### PR TITLE
Document how to get in touch with the JupyterHub Team Council

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,3 +90,6 @@ rediraffe_redirects = {
     # Add additional redirects below if you relocate documents
     # "old/folder/old-file": "new-folder/new-file",
 }
+
+def setup(app):
+    app.add_crossref_type("team", "team")

--- a/docs/practices/communication.md
+++ b/docs/practices/communication.md
@@ -8,7 +8,7 @@ maintainers find and choose the right communication channels and have a positive
 We break down team discussions into two broad categories:
 
 1. **For specific discussions related to changing a repository's content** we use GitHub issues in the repository where they are most relevant. For example, feature requests, bug reports.
-2. **For general discussion, support questions, feedback, etc**, use [the Jupyter forum](http://discourse.jupyter.org/).
+2. **For general discussion, support questions, feedback, etc**, use [the Jupyter forum](https://discourse.jupyter.org/).
 
 ## How to get in touch with the JupyterHub Council
 

--- a/docs/practices/communication.md
+++ b/docs/practices/communication.md
@@ -3,11 +3,19 @@
 We organize our discussions in order to help both contributors and
 maintainers find and choose the right communication channels and have a positive experience :-)
 
-In this respect, we use:
+## Types of discussions
 
-1. GitHub issues for specific discussions related to changing a repository's content
-(e.g. feature requests, bug reports).
-2. The [Discourse forum](http://discourse.jupyter.org/) for general discussions, support questions, or just as a place where we can inspire each other.
+We break down team discussions into two broad categories:
+
+1. **For specific discussions related to changing a repository's content** we use GitHub issues in the repository where they are most relevant. For example, feature requests, bug reports.
+2. **For general discussion, support questions, feedback, etc**, use [the Jupyter forum](http://discourse.jupyter.org/).
+
+## How to get in touch with the JupyterHub Council
+
+There are two recommended ways to send communications to the {team}`JupyterHub Council`:
+
+1. **Open an issue in our [Team Compass](https://jupyterhub-team-compass.readthedocs.io)**. We use this as a space for team discussion of all kinds, and JupyterHub Council members are expected to monitor these issues. **This is the preferred space for most team conversation**.
+2. **Send an e-mail to [`jupyterhub-team-council@googlegroups.com`](mailto:jupyterhub-team-council@googlegroups.com)**. This is a shared inbox that we use for people that prefer non-public or e-mail communication instead of GitHub issues.
 
 ## Gitter channels
 

--- a/docs/practices/communication.md
+++ b/docs/practices/communication.md
@@ -14,7 +14,7 @@ We break down team discussions into two broad categories:
 
 There are two recommended ways to send communications to the {team}`JupyterHub Council`:
 
-1. **Open an issue in our [Team Compass](https://jupyterhub-team-compass.readthedocs.io)**. We use this as a space for team discussion of all kinds, and JupyterHub Council members are expected to monitor these issues. **This is the preferred space for most team conversation**.
+1. **Open an issue in our [Team Compass](https://github.com/jupyterhub/team-compass/issues)**. We use this as a space for team discussion of all kinds, and JupyterHub Council members are expected to monitor these issues. **This is the preferred space for most team conversation**.
 2. **Send an e-mail to [`jupyterhub-team-council@googlegroups.com`](mailto:jupyterhub-team-council@googlegroups.com)**. This is a shared inbox that we use for people that prefer non-public or e-mail communication instead of GitHub issues.
 
 ## Gitter channels

--- a/docs/team/structure.md
+++ b/docs/team/structure.md
@@ -50,6 +50,8 @@ JupyterHub is organized into a few teams with varying levels of responsibility a
 :depth: 1
 ```
 
+```{team} JupyterHub Contributors
+```
 ### JupyterHub Contributors
 
 Comprised of any individuals that have made significant contributions to the project.
@@ -115,6 +117,9 @@ There is no limit to the number of maintainers that may exist in the JupyterHub 
 
 Our goal is to have at least two maintainers for any project within the JupyterHub community.
 
+```{team} JupyterHub Council
+```
+
 ### Steering Council
 
 This group focuses more of their efforts on leadership and stewardship over the JupyterHub community, ensures its long-term impact and sustainability, and represents the JupyterHub community with the broader Jupyter community.
@@ -137,6 +142,9 @@ Steering Council members are elected by other Steering Council members following
 #### Team size
 
 There is no limit on the number of Steering Council members we may have, though we believe 5-10 people is a healthy number.
+
+```{team} Mybinder Team
+```
 
 ### `mybinder.org` operations team
 
@@ -162,6 +170,9 @@ Any team member of this team may be added by any other team member, following a 
 #### Team size
 
 There is no limit to the number of mybinder.org operations team members.
+
+```{team} Team Lead
+```
 
 ### Team Lead
 


### PR DESCRIPTION
This documents our preferred practices for communicating with the JupyterHub Team Council.

- closes #598 