### PR TITLE
HPC notes 2022-12-07

### DIFF
--- a/docs/meetings/hpc/2022-12-07.md
+++ b/docs/meetings/hpc/2022-12-07.md
@@ -1,0 +1,82 @@
+---
+tags: meeting, notes
+---
+
+# JupyterHub HPC Meeting - December 2022
+
+- **Date:** 2022-12-07
+- **Time:** 8:30 AM PST
+  - **Your timezone:** https://arewemeetingyet.com/Los%20Angeles/2022-12-07/08:30/JupyterHub-HPC
+- **Where you can find these and past meeting notes:** https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings/hpc/ 
+- **Calendar for future meetings:** https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings/
+
+## Welcome to the Meeting
+
+Hello! If you are joining the team video meeting, sign in below so we know who was here. Roll call:
+
+- **name** / **institution** / **GitHub handle**
+- Michael Milligan / MSI @ UMN / @mbmilligan
+- Jens Henrik Goebbert / JSC @ FZJ / @jhgoebbert
+- Rollin Thomas / NERSC / @rcthomas
+- 
+
+## Quick updates
+
+60 second updates on things you have been up to, questions you have, or developments you think people should know about. This is also a chance to suggest a future presentation if you've got work currently in progress you might want to share. Please add yourself, and if you do not have an update to share, you can pass.
+
+- **Name:** Your report or celebration
+    - Jens Henrik Göbbert
+        - SLURM Wrapped Kernels (by Tim Kreuzer)
+            - https://github.com/FZJ-JSC/jupyter-slurm-provisioner
+            - https://github.com/FZJ-JSC/jupyter-slurm-provisioner-extension
+            - https://docs.jupyter-jsc.fz-juelich.de/github/FZJ-JSC/jupyter-jsc-notebooks/blob/master/05-News%26Updates/Announcement-2022-12_Slurm_Wrapped_Kernels.ipynb
+        - New features of JLab option dialog (by Alice Grosch)
+
+## Reports and celebrations
+
+This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
+
+- **Name:** Your report or celebration
+- 
+
+## Agenda items
+
+Let's collect all potential agenda items here before the start of the meeting. We will then attempt to create a coherent agenda that fits in the 60m meeting slot. If there are similar items try and group them together.
+
+- **All:** Standing project items:
+    - Batchspawner check-in: Issues and PRs
+        - Still to-do from previous months:
+            - PR updating test matrix - https://github.com/jupyterhub/batchspawner/pull/252
+            - Docs fixing (not overriding master templates)
+        - Merge fix for JupyterHub 3 compatibility in singleuser?
+            - e.g. https://github.com/jupyterhub/batchspawner/pull/247
+            - Ryan is running this in production w/Hub 3 for a while
+    - Wrapspawner check-in: Issues and PRs
+        - Quiet
+- Advertising
+    - Should HPC be its own subproject or some kind of more official interest group?
+    - Broadening beyond Hub is happening
+- Workshop/conference news:
+    - JupyterCon 2023
+        - Cite des Sciences, Paris 
+        - May 10-12
+        - https://www.jupytercon.com/
+        - CfP ends December 15
+    - PEARC 2023 CfP is out
+        - papers/short papers due March/April
+- Abandoned things to revive/decide fate of?
+    - https://github.com/jupyterhub/research-facilities
+    - https://github.com/jupyterhub/jupyterhub-deploy-hpc
+    - Jupyter (not just hub) in HPC subproject?
+        - Rollin will look at this in December and propose in January?
+- Request for assistance/guidance on jupyterhub-singleuser/portwrap integration (ryanlovett)
+    - Mike and Ryan will talk offline
+    - portwrap is a CLI with command you want put in a namespace
+    - somewhere in the config instead of invoking jupyter, you could just run portwrap
+        - But it wants to run jupyterhub-singleuser
+        - How to configure the actual command that jupyterhub-singleuser invokes
+- Announcements from the jupyterhub-announcement service can appear in JupyterLab too:
+    - https://github.com/rcthomas/jupyterhub-announcement
+    - https://github.com/Josh0823/nersc-refresh-announcements
+
+## Links Shared

--- a/docs/meetings/hpc/index.md
+++ b/docs/meetings/hpc/index.md
@@ -10,6 +10,7 @@ To generate the agenda for a new meeting, see the [Monthly Meeting Agenda Templa
 :caption: Monthly reports
 :maxdepth: 1
 
+December 2022 <2022-12-07.md>
 November 2022 <2022-11-02.md>
 October 2022 <2022-10-05.md>
 September 2022 <2022-09-07.md>


### PR DESCRIPTION
Interesting "slurm-wrapped" kernels demo from @jhgoebbert (see quick updates section).  And @mbmilligan and @ryanlovett have a plan to talk offline about [portwrap](https://github.com/ryanlovett/portwrap) integration.