### PR TITLE
Auto-linkify full URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,8 +51,13 @@ html_context = {
 # -- MyST Markdown configuration ----------------------------------------
 # ref: https://myst-parser.readthedocs.io/en/latest/configuration.html
 
-myst_enable_extensions = []
+myst_enable_extensions = [
+    "linkify",
+]
 
+# Only linkify URLs that start with schema
+# https://myst-parser.readthedocs.io/en/latest/syntax/optional.html#linkify
+myst_linkify_fuzzy_links = False
 
 # -- Update contributor lists --------------------------------------------
 

--- a/docs/meetings/community/2018-07-19.md
+++ b/docs/meetings/community/2018-07-19.md
@@ -83,7 +83,7 @@ If you are joining the team video meeting, sign in below so we know who was here
 5. Team News and Informational items
 - 5.1 Organization highlights 
 - 5.2 BinderHub projects
-    - https://gitlab.com/gitlab-org/gitlab-ce/issues/48236 Tim isn't sure what exactly they are planning but I made a suggestion for what I think would be cool.
+    - `https://gitlab.com/gitlab-org/gitlab-ce/issues/48236` Tim isn't sure what exactly they are planning but I made a suggestion for what I think would be cool.
 - 5.3 JupyterHub projects
 - 5.4 Related projects (repo2docker, nbgrader, others)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+linkify-it-py
 myst_parser
 pandas
 pydata_sphinx_theme


### PR DESCRIPTION
A lot of the meeting notes use unformatted URLs e.g. 
`This HackMD: https://hackmd.io/@sgibson91/hubs-team-meeting`

These URLs currently aren't hyperlinked. The linkify extension will convert `scheme://urls` text to hyperlinks.

Alternatively we could go through all our notes and convert `https://url` to [`<https://url>`](https://myst-parser.readthedocs.io/en/latest/syntax/syntax.html#commonmark) and remember to convert them when writing future notes but this is easier.