### PR TITLE
Document the jupyterhub bot

### DIFF
--- a/docs/index-team_policies.md
+++ b/docs/index-team_policies.md
@@ -31,5 +31,6 @@ practices/check-ins
 
 practices/pull_requests
 practices/repository-code-standards
+practices/releases
 practices/readme-badges
 ```

--- a/docs/practices/releases.md
+++ b/docs/practices/releases.md
@@ -1,0 +1,10 @@
+# Making releases
+
+```{admonition} Under construction
+We're still working out our release practices, check back for more information!
+```
+
+## Shared PyPI bot
+
+We have a shared PyPI bot to publish packages to PyPI.
+See [](shared:pypi-bot).

--- a/docs/resources/shared-infrastructure.md
+++ b/docs/resources/shared-infrastructure.md
@@ -8,6 +8,15 @@ Some of these are useful for our development workflows, while others are used as
 We have [a GitHub organization](https://github.com/jupyterhub/) for hosting all of our code repositories.
 This organization is where we do most of the code-related work for the project, and where we have discussions and coordination.
 
+(shared:pypi-bot)=
+## PyPI
+
+We have a [bot named `jupyterhub-bot`](https://pypi.org/user/jupyterhub-bot/) on PyPI.
+This allows us to centralize the authority to publish PyPI packages in a single place.
+We can also use this bot to generate API tokens that allow us to publish packages automatically with GitHub Actions.
+
+Any steering council member should have access to this bot, ask somebody if you'd like access.
+
 (resources:shared-drive)=
 
 ## Google Drive


### PR DESCRIPTION
In #524 I noticed that @consideRatio added a `jupyterhub-bot` as an owner on our PyPI package. This isn't documented anywhere in our team compass but seems pretty important. So this PR adds lightweight documentation about it and a new (and mostly empty) releases section.