### PR TITLE
HPC notes for 2023 04 05

### DIFF
--- a/docs/meetings/hpc/2023-04-05.md
+++ b/docs/meetings/hpc/2023-04-05.md
@@ -1,0 +1,78 @@
+---
+tags: meeting, notes
+---
+
+# JupyterHub HPC Meeting - April 2023
+
+- **Date:** 2023-04-05
+- **Time:** 8:30 AM PDT
+  - **Your timezone:** https://arewemeetingyet.com/Los%20Angeles/2023-04-04/08:30/JupyterHub-HPC
+- **Where you can find these and past meeting notes:** https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings/hpc/ 
+- **Calendar for future meetings:** https://jupyterhub-team-compass.readthedocs.io/en/latest/meetings/
+
+## Welcome to the Meeting
+
+Hello! If you are joining the team video meeting, sign in below so we know who was here. Roll call:
+
+- **name** / **institution** / **GitHub handle**
+- Rollin Thomas / NERSC / @rcthomas
+- Mridul Seth / Anaconda / @MridulS
+- Michael Milligan / MSI @ U of MN / @mbmilligan
+- Félix-Antoine Fortin / Université Laval / @cmd-ntrf
+
+## Quick updates
+
+60 second updates on things you have been up to, questions you have, or developments you think people should know about. This is also a chance to suggest a future presentation if you've got work currently in progress you might want to share. Please add yourself, and if you do not have an update to share, you can pass.
+
+- **Name:** Your report or celebration
+- **Félix-Antoine Fortin**: jupyter-lmod will supports Tmod in the next release. https://github.com/cmd-ntrf/jupyter-lmod
+
+## Reports and celebrations
+
+This is a place to make announcements (without a need for discussion). This is also a great place to give shout-outs to contributors! We'll read through these at the beginning of the meeting.
+
+- **Name:** Your report or celebration
+- **Rollin:** Tested out Traefik proxy (1.0.0b release) with Traefik v2 and it worked after a trailing slash fix https://github.com/jupyterhub/traefik-proxy
+
+## Agenda items
+
+Let's collect all potential agenda items here before the start of the meeting. We will then attempt to create a coherent agenda that fits in the 60m meeting slot. If there are similar items try and group them together.
+
+- Adding an "HPC" tag to the Discourse
+    - Step along the way to subproject?
+    - Discourse has categories and tags
+        - JupyterLab, JupyterHub are categories
+        - "security" and "analytics" are tags
+        - Some categories show up as tags too :shrug:
+        - Makes sense to have a tag that can be applied across multiple categories (Hub topics, Lab topics, Kernel topics, all could be tagged as HPC issues)
+    - Usage of Discourse by Jupyter projects:
+        - Reserve GitHub issue trackers for bugs
+        - Forward support issues to Discourse
+        - => Rollin: Could suggest same, with #hpc tag?
+        - IIRC there's a template response or bot JupyterHub uses for this
+    - Advertise these meetings on Discourse generally but tag as HPC too.
+    - Should we try to gather/list repos that make sense to discuss on Discourse?  Make an announcement about this:
+        - BatchSpawner
+        - WrapSpawner
+        - jupyter-lmod
+        - jupyterhub-announcement?
+        - jupyter-slurm-provisioner
+    - Another topic: Who is running what?  Can we use that as input on the text matrix?  How often do people upgrade their hub?  This is a good way to get feedback.
+- **All:** Standing project items:
+    - Batchspawner check-in: Issues and PRs
+        - hoping for new release soon
+        - want to fix sqlalchemy version issues that cause tests for older versions to spuriously fail
+    - Wrapspawner check-in: Issues and PRs
+        - Options form PR
+        - Rollin should move aside that last commit about auto-vivifying server since it breaks later hubs probably
+- Workshop/conference news:
+    - JupyterCon 2023
+        - Rollin, Mridul
+    - PEARC 2023 CfP
+        - Michael
+        - Deadline for short papers/posters coming up soon
+    - Jupyter security workshop w/Trusted CI in October
+- Community
+    - [Online Collaboration Café](https://blog.jupyter.org/online-collaboration-caf%C3%A9-launch-jupyterhub-team-meetings-to-become-more-collaborative-spaces-b713edadf15) (?)
+
+## Links Shared

--- a/docs/meetings/hpc/index.md
+++ b/docs/meetings/hpc/index.md
@@ -10,6 +10,7 @@ To generate the agenda for a new meeting, see the [Monthly Meeting Agenda Templa
 :caption: Monthly reports
 :maxdepth: 1
 
+April 2023 <2023-04-05.md>
 March 2023 <2023-03-01.md>
 February 2023 <2023-02-01.md>
 January 2023 <2023-01-04.md>


### PR DESCRIPTION
This month:

- [jupyter-lmod](https://github.com/cmd-ntrf/jupyter-lmod) news: Contributions are being made to make it work with tcl too
- Encourage to test jupyterhub-traefik-proxy 1.0 beta
- HPC tag on Discourse?
- Batchspawner test matrix work (sqlalchemy vs python versions)
- Wrapspawner PR merged realtime
- Workshop/conference roundup