### PR TITLE
Document funding sources and how to file a reimbursement

### DIFF
--- a/docs/index-team_policies.md
+++ b/docs/index-team_policies.md
@@ -20,6 +20,7 @@ Jupyter Code of Conduct <https://jupyter.org/governance/conduct/code_of_conduct.
 
 practices/communication
 practices/external-communication
+practices/funding
 practices/adding-members
 practices/check-ins
 ```

--- a/docs/practices/funding.md
+++ b/docs/practices/funding.md
@@ -9,7 +9,7 @@ Currently we do not have formal processes for approving funding, and we make dec
 ### CZI Community Strategic Lead grant
 
 We have a grant from CZI to fund a Community Strategic Lead position.
-Find all of the grant materials, budget, etc at [this Google Drive folder](https://drive.google.com/drive/folders/1Qk_6IvMwtS9F2yKzF4-wtrng6IJK7Dy6?usp=share_link)l
+Find all of the grant materials, budget, etc at [this Google Drive folder](https://drive.google.com/drive/folders/1Qk_6IvMwtS9F2yKzF4-wtrng6IJK7Dy6?usp=share_link).
 
 ### mybinder.org donations
 

--- a/docs/practices/funding.md
+++ b/docs/practices/funding.md
@@ -1,0 +1,31 @@
+# Funding and reimbursements
+
+## Who can spend funds
+
+Currently we do not have formal processes for approving funding, and we make decisions about where to spend funds similarly to [our other decision making processes](#prs:when-to-merge).
+
+## Funds available to this project
+
+### CZI Community Strategic Lead grant
+
+We have a grant from CZI to fund a Community Strategic Lead position.
+Find all of the grant materials, budget, etc at [this Google Drive folder](https://drive.google.com/drive/folders/1Qk_6IvMwtS9F2yKzF4-wtrng6IJK7Dy6?usp=share_link)l
+
+### mybinder.org donations
+
+The mybinder.org service has a button to send donations directly to NumFocus to support the project.
+These funds are controlled directly by NumFocus and we must submit reimbursements to them in order to spend them.
+
+To learn how much funds we have, send an e-mail to `finance@numfocus.org` to ask.
+
+To spend these funds, see [](#funding:numfocus-reimbursement).
+
+(funding:numfocus-reimbursement)=
+## How to get reimbursed from NumFocus
+
+If you spend money that should be reimbursed from a NumFocus grant or account, fill out the typeform below to submit the reimbursement.
+
+```{button-link} https://numfocus.typeform.com/to/O4K2Zol6
+:color: primary
+File a reimbursement
+```

--- a/docs/practices/pull_requests.md
+++ b/docs/practices/pull_requests.md
@@ -31,6 +31,7 @@ Any exceptions to this should be explicitly listed in team documentation.[^1]
   We do not provide many strict rules and technical barriers because we trust team members to use their best judgment in reviewing and merging work.
   Do your best to live up to our team values and practices, and recognize that we all make mistakes.
 
+(prs:when-to-merge)=
 ## When to merge pull requests
 
 - **Obvious and simple improvements** can be merged by any member of the {team}`Maintainer Team`, even if it does not have a review.


### PR DESCRIPTION
This documents how we can file reimbursements with NumFocus, and also adds a page documenting the funding currently available to the project.

- closes: https://github.com/jupyterhub/team-compass/issues/646