### PR TITLE
Add docs on the collaboration cafe meeting

### DIFF
--- a/docs/meetings/collab-cafe/2023.md
+++ b/docs/meetings/collab-cafe/2023.md
@@ -1,0 +1,175 @@
+# 2023 Collaboration Cafe Notes Archive
+
+## 2023-06-20
+
+### NFDI feedback
+
+#### Notes
+
+- Related issue: <https://github.com/jupyterhub/team-compass/issues/644>
+  - Includes presentation with some technical implementation ideas
+- Looking for experiences with other big consortia
+- Experiences with setting up governances
+- And emotional support :D
+- 10 consortia all got funded for something-related to JupyterHub
+  - numerical solutions
+  - biology
+- National infrastructure, there should be synergy between the domains
+  - Base services needed by everyone, e.g., authentication, low-level hosting
+- Jupyter-NFDI
+  - 10 different institutions, need a synergetic agenda for that
+- Federation between different JupyterHubs
+  - Some on k8s, some on bare metal (BatchSpawner)
+  - Develop a backend spawner to link these together with web API (?)
+- Difficult problem (knowledge)
+  - Participants have first-time contact with GitHub (eg)
+  - Judging what kind of code is reliable
+  - Time limit
+- Arnim would like to see:
+  - governance structure that can grow and get more stable
+  - multiple hubs come together on a tech stack 'approved' by the jupyter community
+  - Not go for spawner with multiple targets, but rather developers access to shared resources (?), e.g. one central Hub
+  - Issues:
+    - Researchers need to run code near data to avoid egress cost / data access issues, so a central hub must be able to launch notebook servers near data (multicluster spawner, RemoteSpawner, etc.)
+  -
+
+### GitLab/GitHub container registry pushing
+
+#### Notes
+
+- Improve current logic to allow people to push built image to the registry associated with the repo
+- At the moment, it is a static string referring to a specific container registry
+- Dynamic URL related to the repo
+- Need user authentication in order to extract information on what repos/registries users can push back to
+- Why is BinderHub involved at all?
+  - Use repo2docker in the native CI provider
+  - Can trigger on push events
+  - It's faster, and will be properly authenticated
+- Creating a hook to get the image slug, versus a fixed string, is a reasonable upstream extension
+- Small number of usecases
+
+### Authentication
+
+#### Notes
+
+Two separate topics
+
+- *Authenticators typically allow all users by default but some shouldn't, can we provide a common config name suggestion and behavior to toggle this?* - [github issue](https://github.com/jupyterhub/jupyterhub/issues/4484)
+- *Existing JupyterHub users allowed or not depending on if `Authenticator.allowed_users` is configured or not - a surprise to avoid?* - [github issue](https://github.com/jupyterhub/jupyterhub/issues/4483)
+
+- Conclusion:
+  - Erik will describe config that is believed to resolve issues from a user perspective, and Min and Erik will discuss from there.
+
+## 2023-05-16
+
+### repo2jupyterlite
+
+- **Description:** New tool for building jupyterlite from a repo, like repo2docker / binder
+- **Participating:** Wayne, Andreas, Raniere, Simon,
+- **Assigned to room number:** Breakout room 1 (Participants pane)
+
+#### Notes
+
+- Please keep notes of the discussion here
+- could have
+- ran into compatibility issues with micromamba
+- where do builds run? Could binder run repo2jupyterlite?
+
+### Maintenance
+
+- **Description:** A room dedicated to maintenance tasks, such as issue triage and PR review.
+- **Participating:** Min, Erik, Mridul, _Sign up here!_
+- **Assigned to room number:** Main room (welcoming duties)
+
+#### Notes
+
+- Continue developing guidelines for how this room operates as per: <https://github.com/jupyterhub/team-compass/issues/617#issuecomment-1398404642>
+- Working on triage in the littlest jupyterhub
+- Releasing jupyterhub-traefik-proxy 1.0 https://github.com/jupyterhub/traefik-proxy/pull/205
+- Make sure to publish
+
+## 2023-04-18
+
+### Notes
+
+- **binderhub service**
+  - <https://github.com/2i2c-org/binderhub-service>
+  - allow build & push without launch
+  - deploys BinderHub itself, not JupyterHub
+  - looking at auth, storage, etc.
+  - Question: can you do both authenticated build-only and not authenticated (existing default binderhub)? Exploring. Probably separate BinderHub instances at the moment, at least.
+  - Use case: research library with authenticated internal use, but public URL for anonymous consumption. Probably two 'totally separate instances'. Could be addressed with a landing page.
+  - Questions about UI -
+    - One option is that we could look at the CodeOcean environment builder interface. It's built on top of a JupyterLab layer: <https://help.codeocean.com/en/articles/1374271-configuring-your-computational-environment-an-overview>
+  - Question about storage - r2d usually builds with repo contents in home directory; persisting this dir would omit repo contents. repo2docker has REPO_DIR build arg to control this.
+  - There is conflict between the experience of persistent user dat and updating the execution environment. mybinder.org tends to conflate both. Theen there's the nbgitpuller approach, where compute environment and content are separated.
+  - Question about what to launch. just JupyterLab, or also RStudio, etc.
+  - Erik tried writing notes separately from this section by mistake, this were the notes:
+    - Intro to binderhub-service
+    - mridul: when to deploy binderhub-service vs binderhub, and does it make sense to use binderhub-service when it comes to having a authenticated binderhub side by side to a non-authenticated binderhub?
+    - erik: I'm not sure, but I believe that binderhub-service efforts should be to help handling the situations when you have an existing jupyterhub where user's storage is relevant as well
+    - UI development?
+      - erik: no UI developed yet, ideas are about making it modular to use a REST API from different webpages, such as jupyterhub's spawner
+      - raniere:
+    - UX conversation:
+      - mridul: git repo folder, user home folder - mridul sees the binderhub repo mostly as a description of the environment, and not having contents in it
+      - arnim: is it only jupyterlab UI or RStudio etc? Are we locking into using only one UI?
+        - erik: both options
+      - chris: arnim what was the mode of usage for persistent binderhub?
+        - tendency towards importing repositories
+        - an idea about "projects"
+        - it was dependent on user stories
+        - Mridul: this is how it was mounted: <https://github.com/gesiscss/persistent_binderhub/blob/6fca456f0cb2711ead60d1dd583c43997c8ab66f/persistent_binderhub/files/jupyterhub/persistent_bhub_config.py#L245>
+- **NFDI-Jupyter proposal (#2)**
+  - A proposal towards nationally available JupyterHub(s) in Germany
+  - Bernd: NFDI (German Data Infrastructure initiative) receives significant funding, 90M EUR/y, spread out over 28 diciplines
+    - A topic of relevance, with sections, involving a research software engineering group
+    - Many independently deployed JupyterHub across german research institutes. A goal to consolidate technical and human resources.
+    - A supercomputing centre in germany has significant experience on deploying JupyterHubs.
+    - CH: There's a similar project to allow spawning user sessions in multiple clusters. It's still a prototype, hasn't been developed in a bit but might be of interest: <https://github.com/yuvipanda/jupyterhub-multicluster-kubespawner>
+      - Two other use-cases where this is often needed
+        - one university with many hubs representing different classes.
+        - a research community with data split across multiple cloud providers, that wish to move users into one or the other
+  - Presentation:
+    - <https://jupyter-jsc.fz-juelich.de>
+    - <https://fz-juelich.sciebo.de/s/HfAdM6umijlyZ0u>
+  - Current BackendSpawner implementation: <https://github.com/kreuzert/jupyterhub-backendspawner>
+  - Currently used backend "manager" implementations (using Django Rest Framework):
+    - UNICORE Manager: <https://gitlab.jsc.fz-juelich.de/jupyterjsc/k8s/images/drf-unicoremgr>
+    - Kubernetes Manager: <https://gitlab.jsc.fz-juelich.de/jupyterjsc/k8s/images/drf-k8smgr>
+  - Jonathan: BackendSpawner makes sense to focus on to become a open-source component
+  - Follow-ups:
+    - @choldgraf is happy to join this effort
+  - Min:
+    - putting the spawners outside the jupyterhub process is something of relevance to do in order to support running jupyterhub with multiple replicas
+    - code in: <https://github.com/kreuzert/jupyterhub-backendspawner/blob/main/backendspawner/backendspawner.py>
+- **Binder credits (#1)**
+  - we now have some funds at NumFOCUS (how much?)
+  - need to do work to disentangle the user capacity from the routing service etc.
+  - Do we want to use AWS for this?
+    - Generally agree yes
+    - SG started this but we hit a blocker on AWS container registry / building.
+    - Simon has a prototype to make it easier to push to Amazon ECR.
+    - So it should now be easier to deploy on AWS
+
+## 2023-03-21
+
+### Notes
+
+- **1/Maintenance**
+  - Eskild:
+    - delegate tasks is hard
+    - create the issues for others to work own is a maintainence work on its own
+    - mark PRs issues that are relevant so that others can help out with these ones
+  - project maintenance  proposals
+  - having the proposal beforehand for people to braninstorm before
+  - where to put new proposals?
+  - Post a maintainence proposal effort first inside a GitHub issue or Discourse for early feedback and then discuss it/propose it in the monthly maintaince meeting.
+    - or in the meeting agenda?
+    - We already have places to post about meetings, so perhaps the GitHub issue announcing the meeting is the place to put maintenance proposals
+- **2/Persistent binderhub**
+  - James
+    - introduces JupyterHub vs BinderHub, clarifies that the binderhub chart deploys binderhub the software, that starts building of images using repo2docker
+    - binderhub was opinionated in removing auth and storage for jupyterhub, so if building on top of this to add it back we have quite a bit of additional complexity
+    - the idea of
+  - How to engage more contributors? Does the project need to be in a different space? What needs to happen?

--- a/docs/meetings/collab-cafe/index.md
+++ b/docs/meetings/collab-cafe/index.md
@@ -1,0 +1,87 @@
+(collab-cafe)=
+
+# Collaboration Cafes
+
+On the third Tuesday of every month, the JupyterHub community host a Collaboration Cafe (or _café_).
+These community events are designed to enable community members to work together and facilitate discussion on any topics they need in breakout rooms, and are open for anyone to attend.
+You can read more about Collaboration Cafe in the resources below.
+
+- [Jupyter blog post](https://blog.jupyter.org/online-collaboration-caf%C3%A9-launch-jupyterhub-team-meetings-to-become-more-collaborative-spaces-b713edadf15)
+- [_The Turing Way_ Collaboration Café guide](https://the-turing-way.netlify.app/community-handbook/coworking/coworking-collabcafe.html)
+
+## Quick info
+
+- Link to running notes: <https://hackmd.io/@sgibson91/jupyterhub-collab-cafe>
+- Link to video conference call: <https://meet.jit.si/jupyterhub-collab-cafe>
+- Link to calendar: [](meetings:calendars)
+
+## Who can join?
+
+Anyone interested in becoming involved in the JupyterHub or Binder community is welcome to attend a Collaboration Cafe.
+You can feel free to use this time as a way to get on with your own JupyterHub-related work, see what topics the community are discussing, or get help on a topic you are working on.
+
+### Default rooms
+
+There are some rooms that will always be available to those who require them or are not sure where to get started.
+
+- **Onboarding:** If you are new to the JupyterHub project, a member of our team can give you an introduction and answer your questions in this room
+- **Maintenance:** A room dedicated to maintenance tasks, such as issue triage and PR review
+- **Quiet working:** The main room will be available for anyone who wishes to quietly work on something JupyterHub related
+
+### Suggesting a breakout topic
+
+There is a template in the HackMD, and copied below, that topic proposers should follow.
+This template ensures that there is enough information about each topic for folk to decide which room they'd like to join without having to go talk through each of them in the main room.
+
+```
+### <Topic Title>
+
+- **Description:** <Please provide enough information here for folk to decide whether they would like to participate or not>
+- **Participating:** <Sign up here!>
+- **Assigned to room number:** <TBA by the facilitator>
+
+#### Notes
+
+- Please keep notes of the discusion
+```
+
+## Hosting a Collaboration Café
+
+Any member of the JupyterHub community should feel empowered to host a Collaboration Cafe if they so wish.
+
+### HackMD running notes and assigning breakout rooms
+
+- The running notes for the Collaboration Cafe are kept here: <https://hackmd.io/@sgibson91/jupyterhub-collab-cafe>
+
+Participants are invited to check-in and propose a topic, or sign up to participate in a topic someone else has suggested.
+The facilitator should assign breakout rooms according to the sign-ups in the HackMD.
+It can be helpful to keep track of which topic has been assigned to which breakout room in the HackMD as well, since the video conferencing platform we use does not support renaming breakout rooms, at time of writing.
+
+**The agenda is very flexible and the facilitator should use their best judgment to structure the cafe according to the needs of the attendees.**
+For example, if everyone has signed up for one topic, the facilitator can decide to not open breakout rooms and instead host the discussion in the main room.
+
+### Video conferencing platform
+
+- The Collaboration Cafe meets in this Jitsi room: <https://meet.jit.si/jupyterhub-collab-cafe>
+
+There is an explainer video that demonstrates how to create and manage breakout rooms in Jitsi: <https://www.youtube.com/watch?v=ubYYZ0daw10>
+
+### Time keeping
+
+- The shared timer is available here: <https://cuckoo.team/jupyterhub-collab-cafe>
+
+The Collaboration Cafe is structured in [pomodoro sprints](https://en.wikipedia.org/wiki/Pomodoro_Technique) and they are timed using the above shared timer.
+The timer syncs across browsers and so anyone who logs in can see how much time is left in the room.
+It is highly encouraged that at least one person in each breakout room has the timer open and timekeeps, especially since Jitsi does not allow broadcasting into breakout rooms to provide warnings, at time of writing.
+
+### Archiving notes
+
+## Archive
+
+Each file represents one year, and entries within a file are in reverse choronological order.
+
+```{toctree}
+:maxdepth: 1
+
+2023 <2023.md>
+```

--- a/docs/meetings/collab-cafe/index.md
+++ b/docs/meetings/collab-cafe/index.md
@@ -76,6 +76,9 @@ It is highly encouraged that at least one person in each breakout room has the t
 
 ### Archiving notes
 
+After each Cafe, we archive the notes in this repository for future reference, and to prevent the HackMD becoming unwieldy.
+You can find the archive at the bottom of this page.
+
 ## Archive
 
 Each file represents one year, and entries within a file are in reverse choronological order.

--- a/docs/meetings/index.md
+++ b/docs/meetings/index.md
@@ -17,18 +17,18 @@ The JupyterHub meeting calendar is embedded below for quick reference:
 
 <iframe src="https://calendar.google.com/calendar/embed?src=aqpkui5q7oi32pk9tcp53hnssc%40group.calendar.google.com&ctz=America%2FLos_Angeles" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
 
-## Notes for monthly team meetings
+## Notes for monthly Collaboration Cafe
 
-The JupyterHub team has a project-wide video meeting each month (see [](meetings:calendars)).
-We use [this HackMD for notes and agenda-setting](https://hackmd.io/@sgibson91/hubs-team-meeting).
+The JupyterHub team has a monthly Collaboration Cafe (see [](meetings:calendars)).
+We use [this HackMD for topic suggestions and capturing discussion](https://hackmd.io/@sgibson91/hubs-team-meeting).
 
-We rotate time zones for each meeting to ensure that there is a timezone-friendly meeting for anyboyd in the world at least once every two months.
+We rotate time zones for each meeting to ensure that there is a timezone-friendly meeting for anybody in the world at least once every two months.
 
 ```{toctree}
 :maxdepth: 2
-:caption: Team meetings
+:caption: Collaboration Cafes
 
-community/index
+collab-cafe/index
 ```
 
 ## Notes for HPC working group
@@ -47,12 +47,13 @@ hpc/index
 
 ## Archive of past meeting types
 
-The JupyterHub team used to keep weekly reports for what they had
-been up to. We recently switched to Monthly sync-ups instead of weekly
-reports, but below is a list of the weekly reports that we have put together.
+The JupyterHub team used to keep monthly and weekly reports for what they had been up to.
+We have switched to a Collaboration Cafe format instead.
+Below is a list of the monthly and weekly reports that we have put together.
 
 ```{toctree}
 :maxdepth: 2
 
+community/index
 weekly-reports/archive
 ```


### PR DESCRIPTION
Adds some documentation to the team compass on the collaboration cafe, particularly around hosting so that I am not on the critical path

I think with this merge, we can close #617 