### PR TITLE
Update release practices with info about use of github-activity etc

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,22 +1,17 @@
-# Read the Docs configuration file for Sphinx projects
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
-# Required
+# Configuration on how ReadTheDocs (RTD) builds our documentation
+# ref: https://readthedocs.org/projects/jupyterhub-team-compass/
+# ref: https://docs.readthedocs.io/en/stable/config-file/v2.html
+#
 version: 2
 
-# Set the OS, Python version and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
 
-# Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
-   install:
-   - requirements: docs/requirements.txt
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/practices/releases.md
+++ b/docs/practices/releases.md
@@ -1,10 +1,132 @@
 # Making releases
 
-```{admonition} Under construction
-We're still working out our release practices, check back for more information!
-```
+To make a new release, we should be able to follow the project's RELEASE.md
+file. Since these files can get outdated, its good to refer to this document and
+our [template project's RELEASE.md file] from time to time to keep it updated.
 
-## Shared PyPI bot
+## Release ambitions
 
-We have a shared PyPI bot to publish packages to PyPI.
-See [](shared:pypi-bot).
+- To document and automate the release process well enough for repository
+  maintainers to have the agency to make regular releases.
+- To follow a versioning scheme such as [SemVer 2], where we update the
+  MAJOR.MINOR.PATCH versions according to the versioning scheme.
+- To maintain changelogs, and update them for each release.
+- To keep release practices across projects updated by upstreaming release
+  practice improvements from individual projects to the [template project]'s
+  files and the [team-compass project]'s documentation, and to to downstream
+  updates from there to other projects.
+
+## Release practices
+
+### Changelog updates with `github-activity`
+
+We look to have our changelogs summarize most pull requests that has been
+merged, we use `github-activity` to help us with this.
+
+#### Create PR list with `github-activity`
+
+1. `pip install -U github-activity`
+
+   Get the latest version.
+
+2. `git checkout main`, `git pull`, `git remote -v`, and `git log`
+
+   Ensure you will work against the latest changelog file and that
+   github-activity will be able to inspect the latest git tags locally.
+
+   The remote and log commands are to help you check you didn't just update
+   against a remote fork.
+
+3. `github-activity --heading-level=3`
+
+   First acquire a preliminary list of pull requests, then revise labels and
+   titles of pull requests, then acquire a final list of pull requests to update
+   the changelog with.
+
+   1. Revise PR labels
+
+      PRs listed under `Other merged PRs` doesn't have a label to make it listed
+      in another category. If you think they should be, visit the PR and add a
+      suitable label to it.
+
+   2. Revise PR titles
+
+      PR titles should describe the change made for readers of a changelog.
+      Check if there is a PR title that is worth updating.
+
+      As an example, in the jupyterhub/oauthenticator projects its relevant for
+      users to know if a change affected a specific authenticator class they
+      use. Due to that, we've tried to let that be captured in the title, such
+      as `[GitHub] Fix ...`.
+
+   3. Revise final list
+
+      Some pull requests could be seen as irrelevant to list, for example we
+      could opt to omit automatic updates to the versions of pre-commit hooks or
+      github actions.
+
+#### Create a changelog entry
+
+1. Come up with the new version number
+
+   Assuming we are using [SemVer 2] as a versioning scheme, we should:
+
+   - increment the major version if a breaking change has been made
+   - increment the minor version if a new features has been added
+   - increment the patch version if a bug has been fixed
+
+2. Update the changelog file
+
+   - Add the previously generated PR list.
+   - Align formatting with previous releases.
+   - Add a preliminary release date.
+   - At least for major releases, lead with a manually written summary.
+
+3. Open a pull request
+
+   Make a commit named like `Add changelog for 1.2.3` and open a PR with it
+   titled the same.
+
+4. Ready for release
+
+   With a changelog PR approved, you can self-merge it and make a release
+   according to the project's RELEASE.md file. Before merging, update the
+   preliminary release date if needed, or add a commit doing it before using
+   `tbump`.
+
+### Version updates with `tbump`
+
+Our RELEASE.md files often describes how to use `tbump` to update version
+strings in files such as `_version.py` in a commit, tag the commit, and push it.
+
+Projects configure `tbump` via `pyproject.toml` to update the project's specific
+files containing a version reference, such as `_version.py`, `setup.py`, and
+`package.json`.
+
+The [template project's pyproject.toml file] provides an example on how to
+configure `tbump`, and the [template project's RELEASE.md file] provides an on
+how to use it.
+
+### Publishing to PyPI
+
+Publishing a release to PyPI should be automatic as soon as a git tag is pushed.
+A git tag is typically pushed by the use of `tbump` according to a RELEASE.md
+file, and the automation to publish to PyPI is typically done by a GitHub
+workflow named `release.yaml`.
+
+The [template project's .github/workflows/release.yaml file] and the [template
+project's RELEASE.md file] can be inspected for more details about this.
+
+### Publishing to conda-forge
+
+Publishing a release to conda-forge should be managed by a dedicated feedstock
+GitHub repository, and the RELEASE.md file should link to it for reference as
+done in the [template project's RELEASE.md file].
+
+[semver 2]: https://semver.org/
+[`github-activity`]: https://github.com/executablebooks/github-activity
+[template project]: https://github.com/jupyterhub/jupyterhub-python-repo-template
+[team-compass project]: https://github.com/jupyterhub/team-compass
+[template project's release.md file]: https://github.com/jupyterhub/jupyterhub-python-repo-template/blob/main/RELEASE.md
+[template project's pyproject.toml file]: https://github.com/jupyterhub/jupyterhub-python-repo-template/blob/main/pyproject.toml
+[template project's .github/workflows/release.yaml file]: https://github.com/jupyterhub/jupyterhub-python-repo-template/blob/main/.github/workflows/release.yaml

--- a/docs/resources/shared-infrastructure.md
+++ b/docs/resources/shared-infrastructure.md
@@ -11,11 +11,20 @@ This organization is where we do most of the code-related work for the project, 
 (shared:pypi-bot)=
 ## PyPI
 
-We have a [bot named `jupyterhub-bot`](https://pypi.org/user/jupyterhub-bot/) on PyPI.
-This allows us to centralize the authority to publish PyPI packages in a single place.
-We can also use this bot to generate API tokens that allow us to publish packages automatically with GitHub Actions.
+We have a [bot account named `jupyterhub-bot`] on PyPI. This has historically
+been used to generate a token for use to publish new releases via our CI system.
+We are however transitioning away from this practice.
 
-Any steering council member should have access to this bot, ask somebody if you'd like access.
+The current practice is to declare that PyPI project's should allow a specific
+GitHub workflow (release.yaml) in the associated GitHub repository to be allowed
+to publish new releases. See our [template GitHub workflow] for more details.
+
+There is a [list of current team members with control of the account], ask if
+you need access or a change made related to the account.
+
+[bot account named `jupyterhub-bot`]: https://pypi.org/user/jupyterhub-bot/
+[template github workflow]: https://github.com/jupyterhub/jupyterhub-python-repo-template/blob/main/.github/workflows/release.yaml
+[list of current team members with control of the account]: https://github.com/jupyterhub/team-compass/issues/520
 
 (resources:shared-drive)=
 

--- a/docs/team/structure.md
+++ b/docs/team/structure.md
@@ -112,7 +112,7 @@ They also inherit all responsibilities from the JupyterHub Contributors team.
 
 Maintainers may be added by any other maintainer.
 To add a new maintainer, a current maintainer should recommend their addition via [issues in our Team Compass](https://github.com/jupyterhub/team-compass), or via private communications channels.
-If there are no objections to adding a new maintainer, add them to [our list of maintainers](index.rst).
+If there are no objections to adding a new maintainer, add them to [our list of maintainers](./index).
 
 #### Team size
 


### PR DESCRIPTION
These are updates to offload individual RELEASE.md files have this kind of info (which then would get outdated over time across many separate projects), and to make it more official than to link to a github issue as done before.

I bundled another semi-related commit in this PR because I didn't think it was important enough to create a dedicated one. That was to make updates to describe that the PyPI jupyterhub-bot account, which has lost a lot of its purpose now that PyPI supports giving temporary credentials to a github workflow.

Preview of PRs changes:
- https://jupyterhub-team-compass--679.org.readthedocs.build/en/679/practices/releases.html
- https://jupyterhub-team-compass--679.org.readthedocs.build/en/679/resources/shared-infrastructure.html

### Related

- https://github.com/jupyterhub/jupyterhub-python-repo-template/pull/21
- https://github.com/jupyterhub/team-compass/issues/563
- New docs location for using github-activity: https://jupyterhub-team-compass.readthedocs.io/en/latest/practices/releases.html