### PR TITLE
Document GitHub @jupyterhub-bot

### DIFF
--- a/docs/resources/shared-infrastructure.md
+++ b/docs/resources/shared-infrastructure.md
@@ -8,6 +8,15 @@ Some of these are useful for our development workflows, while others are used as
 We have [a GitHub organization](https://github.com/jupyterhub/) for hosting all of our code repositories.
 This organization is where we do most of the code-related work for the project, and where we have discussions and coordination.
 
+### @jupyterhub-bot
+
+[@jupyterhub-bot is a GitHub bot account](https://github.com/jupyterhub-bot)
+that can be used to create unprivileged GitHub tokens, for example to
+[open automated PRs](https://github.com/search?q=org%3Ajupyterhub+author%3Ajupyterhub-bot&type=pullrequests)
+without the limitations of the [default `GITHUB_TOKEN`](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).
+
+If these tokens are stored as a repository secret for a single workflow it should never be necessary to store a copy of them- just delete and create a new token instead, and update the secret.
+
 (shared:pypi-bot)=
 ## PyPI
 


### PR DESCRIPTION
I need to create a new token for https://github.com/jupyterhub/mybinder.org-deploy/blob/bab0a754590ee1aa9fdd5de023411be4edd57d28/.github/workflows/update-grafana-data.yaml
but I don't have access to the bot account, and I realised it's not documented.

- [ ] Who's got access to it, and where should we record that list?