### PR TITLE
Fix duplicated key in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/collab_cafe.md
+++ b/.github/ISSUE_TEMPLATE/collab_cafe.md
@@ -1,5 +1,5 @@
 ---
-title: Schedule a Collaboration Cafe
+name: Schedule a Collaboration Cafe
 about: Provide all the information about an upcoming Community Collaboration Cafe
 title: "JupyterHub and Binder Collab Cafe | [Month, Year]"
 ---


### PR DESCRIPTION
I think this is why the template in this repo isn't overriding the defaults from the .github repo