### PR TITLE
create JupyterHealth team

### DIFF
--- a/docs/_data/contributors/contributors-jupyterhub.yaml
+++ b/docs/_data/contributors/contributors-jupyterhub.yaml
@@ -59,6 +59,15 @@
     - council
   last-check-in: 2022-09
 
+- name: Ryan Lovett
+  handle: ryanlovett
+  affiliation: UC Berkeley
+  contributions: code,question
+  focus: jupyterhub, health
+  teams:
+    - health
+  last-check-in: 2025-01
+
 - name: Yuvi Panda
   handle: "yuvipanda"
   affiliation: UC Berkeley
@@ -66,6 +75,7 @@
   focus: jupyterhub
   teams:
     - council
+    - health
   last-check-in: 2022-09
 
 - name: Fernando Pérez
@@ -75,6 +85,7 @@
   focus: jupyterhub
   teams:
     - council
+    - health
   last-check-in: 2022-09
 
 - name: Min Ragan-Kelley
@@ -84,6 +95,7 @@
   focus: jupyterhub, binder
   teams:
     - council
+    - health
   last-check-in: 2022-09
 
 - name: Erik Sundell
@@ -104,6 +116,14 @@
     - council
   last-check-in: 2022-09
 
+- name: Maryam Vareth
+  handle: maryamv
+  affiliation: UC Berkeley
+  contributions: ideas,fundingFinding
+  focus: health
+  teams:
+    - health
+  last-check-in: 2025-01
 
 # Inactive team members at the end, also alphabetical
 - name: Matthias Busonnier

--- a/docs/_data/contributors/gen_contributors.py
+++ b/docs/_data/contributors/gen_contributors.py
@@ -22,6 +22,7 @@ inactive_contributors = []
 
 team_titles = {
     "council": "JupyterHub Council",
+    "health": "JupyterHealth",
     "maintainers": "Maintainers",
     "mybinder": "mybinder.org operators",
 }

--- a/docs/team/structure.md
+++ b/docs/team/structure.md
@@ -204,6 +204,27 @@ There is no limit to the number of Security team members.
 ```{team} Team Lead
 ```
 
+### JupyterHealth Team
+
+The JupyterHealth team is responsible for the [jupyterhealth](https://github.com/jupyterhealth) GitHub organization.
+JupyterHealth is a fledgeling project with a different level of maturity and expectation than the rest of JupyterHub.
+The JupyterHub project maintainers are not expected to take on maintenance responsibilities for the JupyterHealth organization unless desired.
+JupyterHealth aims to coordinate stakeholders for Jupyter in healthcare settings, and is focused more on documentation and community development than software tools.
+
+#### Expectations and responsibilities
+
+JupyterHealth team expectations and responsibilities align with the Maintainers team, but focused on the [jupyterhealth](https://github.com/jupyterhealth) GitHub organization instead of JupyterHub more generally.
+
+#### How to join
+
+JupyterHealth Maintainers may be added by any other JupyterHealth maintainer.
+To add a new maintainer, a current maintainer should recommend their addition via [issues in our Team Compass](https://github.com/jupyterhub/team-compass), or via private communications channels.
+If there are no objections to adding a new maintainer, add them to [our list of maintainers](./index).
+
+#### Team size
+
+There is no limit to the number of JupyterHealth team members.
+
 ### Team Lead
 
 The Team Lead is a role with impasse-breaking authority to


### PR DESCRIPTION
implementation of #752 which has more details on the proposal. Feel free to ask questions here or there if there are any questions or concerns with (or especially objections to!) the proposal.

If this is merged, I'll go ahead and add jupyterhealth to the Jupyter GitHub Enterprise and consider the process complete

Any more tasks to take?