### PR TITLE
update chat links to Zulip

### DIFF
--- a/docs/contribute/guide.md
+++ b/docs/contribute/guide.md
@@ -41,8 +41,8 @@ are a few places where we have conversations and discussion.
   repositories focused around more actionable items.
 * [The JupyterHub team meeting](../meetings/index) takes place once a month, and is open to anybody who
   would like to attend. We try to use this as an opportunity to sync-up and connect with the community.
-* The [JupyterHub Gitter channel](https://gitter.im/jupyterhub/jupyterhub) and [Binder gitter channel](https://gitter.im/jupyterhub/binder)
-  are for in-person conversation. In general, if conversations last beyond a few seconds, we highly encourage you
+* The [JupyterHub Zulip channel](https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub/)
+  is for in-person conversation. In general, if conversations last beyond a few seconds, we highly encourage you
   to open a thread in the [JupyterHub Discourse page](https://discourse.jupyter.org) instead!
 
 As a reminder, we expect all members of the JupyterHub community to adhere to the

--- a/docs/meetings/collab-cafe/facilitator-checklist.md
+++ b/docs/meetings/collab-cafe/facilitator-checklist.md
@@ -10,12 +10,12 @@ All links for running the cafe will be in a GitHub issue that should be created 
 **1 week before:**
 
 - Post a comment on the issue in the Team Compass repo reminding folk that the meeting is one week away
-- _TBA: Any updates to announcements posted in other spaces, e.g., Discourse, Gitter, Twitter/Mastodon, etc._
+- _TBA: Any updates to announcements posted in other spaces, e.g., Discourse, Zulip, Mastodon, etc._
 
 **1 day before:**
 
 - Post a comment on the issue in the Team Compass repo reminding folk that the meeting is the next day
-- _TBA: Any updates to announcements posted in other spaces, e.g., Discourse, Gitter, Twitter/Mastodon, etc._
+- _TBA: Any updates to announcements posted in other spaces, e.g., Discourse, Zulip, Mastodon, etc._
 
 ## During the Meeting
 
@@ -29,7 +29,7 @@ If you join the jitsi link a few minutes before the meeting starts, you'll see a
 - Ask for a volunteer to act as the primary note taker, but emphasise that notes are collaborative and all attendees should add to them, especially when dealing with complex topics
 - Work your way through the shared document, starting with intros and celebrations before moving into the main agenda
     - Try to ensure everybody who wishes to gets an opportunity to speak. Keep an eye on the Raised Hands in the meeting.
-    - Try to keep an eye on timing so that all the topics can be covered without overrunning. This may mean interrupting some discussions and suggesting they be continued asynchronously (Gitter, Discourse, or GitHub are good places to point folk to).
+    - Try to keep an eye on timing so that all the topics can be covered without overrunning. This may mean interrupting some discussions and suggesting they be continued asynchronously (Zulip, Discourse, or GitHub are good places to point folk to).
     - Make sure to leave time for any questions before moving into the next agenda item.
 - To close out the meeting, thank everyone for attending and remind them of the timezone of the next meeting.
 
@@ -47,4 +47,4 @@ If you join the jitsi link a few minutes before the meeting starts, you'll see a
     - Clear the shared document of topics and notes
     - Update the date, time and time converter link in the info box at the top of the shared document
     - [Open a new meeting issue](https://github.com/jupyterhub/team-compass/issues/new?assignees=&labels=&projects=&template=collab_cafe.md&title=JupyterHub+and+Binder+Collab+Cafe+%7C+%5BMonth%2C+Year%5D) and populate with the information you just updated in the shared document
-    - _TBA: Advertise in other places, e.g., Dicourse, Gitter, Twitter/Mastodon, etc._
+    - _TBA: Advertise in other places, e.g., Discourse, Zulip, Mastodon, etc._

--- a/docs/practices/communication.md
+++ b/docs/practices/communication.md
@@ -17,18 +17,18 @@ There are two recommended ways to send communications to the {team}`JupyterHub C
 1. **Open an issue in our [Team Compass](https://github.com/jupyterhub/team-compass/issues)**. We use this as a space for team discussion of all kinds, and JupyterHub Council members are expected to monitor these issues. **This is the preferred space for most team conversation**.
 2. **Send an e-mail to [`jupyterhub-team-council@googlegroups.com`](mailto:jupyterhub-team-council@googlegroups.com)**. This is a shared inbox that we use for people that prefer non-public or e-mail communication instead of GitHub issues.
 
-## Gitter channels
+## Chat
 
-We use several gitter channels to have synchronous conversation across projects.
+We use some chat channels to have synchronous conversation across projects.
+Jupyter has recently adopted Zulip for chat, to replace the old Gitter/Matrix chat rooms.
 If a conversation will likely span multiple hours, or is relevant to many people, consider opening a thread in Discourse or the `team-compass` repository instead.
-Here are the relevant Gitters:
+Here are the relevant chat links:
 
- * [The JupyterHub Gitter](https://gitter.im/jupyterhub/jupyterhub) is for
-   discussing JupyterHub, Z2JH, TLJH, etc.
- * [The Binder Gitter](https://gitter.im/jupyterhub/binder) is for
-   discussion with Binder users about how to use Binder.
- * [The mybinder.org-deploy gitter](https://gitter.im/jupyterhub/mybinder.org-deploy)
-   is for discussion around **operating myinder.org**.
+* [The Jupyter Zulip](https://jupyter.zulipchat.com) is where Jupyter-related chat is taking place.
+  You can use topics to thread conversations on particular areas.
+
+* [The JupyterHub channel](https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub) is for
+  discussing JupyterHub, Binder, Z2JH, TLJH, etc.
 
 ## Support bot
 

--- a/docs/practices/readme-badges.md
+++ b/docs/practices/readme-badges.md
@@ -138,7 +138,7 @@ specified.
 ```
 
 
-[![Gitter](https://img.shields.io/badge/social_chat-gitter-blue?logo=gitter)](https://gitter.im/jupyterhub/jupyterhub)
+[![Zulip](https://img.shields.io/badge/social_chat-zulip-blue?logo=zulip)](https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub)
 ```md
-[![Gitter](https://img.shields.io/badge/social_chat-gitter-blue?logo=gitter)](https://gitter.im/jupyterhub/jupyterhub)
+[![Zulip](https://img.shields.io/badge/social_chat-zulip-blue?logo=zulip)](https://jupyter.zulipchat.com/#narrow/channel/469744-jupyterhub)
 ```


### PR DESCRIPTION
removes links to gitter, replaces with Zulip

not-in-this-repo tasks:

- add note in room descriptions on gitter/matrix to deprecate/link to Zulip
- update badges in readmes, if/where we have them

closes #751