### PR TITLE
Add a link for new contributors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,12 +13,13 @@
 Our Team Compass contains team practices, policies, and resources to help one another align and contribute.
 It also has helpful information for team members, like shared infrastructure and accounts, resources to learn how to contribute, etc.
 
-:::{card} Interested in contributing? Start here ✨
-:link-ref: contribute/guide.md
+```{card} Interested in contributing? Start here ✨
+:link: contribute/guide
+:link-type: doc
 Our Team Compass is also a way for others to learn our practices so that they can more effectively contribute.
 +++
 Click here to see our contributing guide.
-:::
+```
 
 We use **[GitHub issues in `jupyterhub/team-compass`](https://github.com/jupyterhub/team-compass/issues)**
 to discuss specific, actionable things related to the *team* (e.g., discussing whether to change something in the team-compass repo).

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,13 @@
 Our Team Compass contains team practices, policies, and resources to help one another align and contribute.
 It also has helpful information for team members, like shared infrastructure and accounts, resources to learn how to contribute, etc.
 
+:::{card} Interested in contributing? Start here ✨
+:link-ref: contribute/guide.md
+Our Team Compass is also a way for others to learn our practices so that they can more effectively contribute.
++++
+Click here to see our contributing guide.
+:::
+
 We use **[GitHub issues in `jupyterhub/team-compass`](https://github.com/jupyterhub/team-compass/issues)**
 to discuss specific, actionable things related to the *team* (e.g., discussing whether to change something in the team-compass repo).
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,7 +8,7 @@ nox.options.reuse_existing_virtualenvs = True
 
 build_command = ["-b", "html", "docs", "docs/_build/html"]
 
-@nox.session(python="3.9")
+@nox.session()
 def docs(session):
     session.install("-r", "docs/requirements.txt")
     if "live" in session.posargs:


### PR DESCRIPTION
I had a conversation with @mfisher87 where he noted that it wasn't clear whether our team compass was just for current team members, or was also for those who wanted to contribute. So this adds a big button to the landing page that is meant to point new contributors in the right direction