### PR TITLE
Sarah stepping back

### DIFF
--- a/docs/_data/contributors/contributors-jupyterhub.yaml
+++ b/docs/_data/contributors/contributors-jupyterhub.yaml
@@ -25,12 +25,12 @@
 
 - name: Sarah Gibson
   handle: "sgibson91"
-  affiliation: 2i2c
+  affiliation: ""
   contributions: question,doc,tutorial,infra,talk,test
   focus: jupyterhub, binder
-  teams:
-    - council
-  last-check-in: 2022-09
+  teams: []
+  last-check-in: 2025-05
+  status: inactive
 
 - name: Chris Holdgraf
   handle: "choldgraf"


### PR DESCRIPTION
Hi everyone,

I wanted to let you know that I’ve decided to step away from my role as a maintainer for the time being. This hasn’t been an easy decision, but personal stress has been building for a while, and I need to focus on getting things in my life back into balance.

This isn’t necessarily a permanent departure. I’m giving myself the space to take a proper break, sort things out, and then reassess. Once I’m in a better place, I’ll make a clearer decision about whether or not I return in a full capacity.

Being part of this project and community has meant a lot to me. I’m proud of what we’ve built together, and I’m deeply grateful to everyone who’s supported me along the way.

Thanks so much for your understanding and support.

Take care,
Sarah ❤️ 