### PR TITLE
Configure RTD to use dirhtml builder

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,7 @@ build:
     python: "3.11"
 
 sphinx:
+  builder: dirhtml
   configuration: docs/conf.py
 
 python:


### PR DESCRIPTION
This should have been part of https://github.com/jupyterhub/team-compass/pull/782 but I forgot it.