### PR TITLE
Add 2025 Collaboration Cafe meeting notes

### DIFF
--- a/docs/meetings/collab-cafe/2025.md
+++ b/docs/meetings/collab-cafe/2025.md
@@ -29,7 +29,7 @@ Let us know that you're here and how we can stay in touch.
  * Kirstie (she/her) / @KirstieJane / Berkeley Institute for Data Science / Berkeley, CA
  * Freek/ @Freek Pols / Delft University of Technology / 
  * Jim / @JimMadge / Alan Turing Institute / Exeter, UK
- * Simon / @manics / University of Dundee / 🏴󠁧󠁢󠁳󠁣󠁴󠁿
+ * Simon / @manics / University of Dundee / :scotland:
  * Arielle / @Arielle-Bennett / Turing Institute /Boston, USA
  * Ryan (he/him) / @ryanlovett / UC Berkeley / California
  * Raniere Silva (he / him) / @rgaiacs / GESIS / Germany


### PR DESCRIPTION
Added detailed notes from the Collaboration Cafe meetings held on October 1, 7, and 8, 2025, including participant check-ins, agendas, discussions, and shout-outs.