### PR TITLE
Add Kirstie to the team

### DIFF
--- a/docs/_data/contributors/contributors-jupyterhub.yaml
+++ b/docs/_data/contributors/contributors-jupyterhub.yaml
@@ -105,6 +105,13 @@
   teams:
     - binder
 
+- name: Kirstie Whitaker 
+  handle: kirstiejane
+  affiliation: University of California, Berkeley
+  contributions: Open Source Governance,Leadership and strategic planning, vision
+  focus: jupyterhub, binder
+  teams: []
+
 - name: Ida Sim
   handle: idasim
   affiliation: UCSF, UC Berkeley


### PR DESCRIPTION
Following up on https://github.com/jupyterhub/team-compass/pull/840, I realized that Kirstie is currently not a part of the team! 

This is belatedly acknowledging all the amazing leadership and community work she has done over a sustained period of time here.

Thank you @kirstiejane