### PR TITLE
Add notes for Collaboration Cafe on 2 December 2025

### DIFF
--- a/docs/meetings/collab-cafe/2025.md
+++ b/docs/meetings/collab-cafe/2025.md
@@ -1,5 +1,92 @@
 # 2025 Collaboration Cafe Notes Archive
 
+## 2025-12-02
+
+### Check-in 💁
+
+Let us know that you're here and how we can stay in touch
+
+* *Name (and pronouns if you'd like) / GitHub handle / affiliation / geographic location*
+* Kirstie Whitaker (she/her) / @KirstieJane / Berkeley Institute for Data Science / Berkeley, CA, USA 
+* Anton Akhmerov / @akhmerov / TU Delft / Delft, ZH, NL
+* Brigitta Sipőcz (she/her) / @bsipocz / Caltech / Seattle, USA
+* Stéfan van der Walt / @stefanv / BIDS, Scientific Python / Truckee, CA
+* Rowan Cockett / @rowanc1 / Curvenote \& Continuous Science Foundation, 🇨🇦
+* Angus Hollands / @agoose77 / 2i2c \& Jupyter Book / Rugby, UK
+* Jake Diamond-Reivich/Jupyter Media Strategy/ New York, NY
+* Jason Grout / @jasongrout / EC / Phoenix, AZ, USA
+
+### Ice breaker 🧊⛏️
+
+*What is your favourite food for this time of year?*
+
+* Kirstie: Lebkuchen! Delicious German gingerbread!
+* Anton: kimchi 
+    * S: I love making kimchi!
+* marzipan in anything
+* Angus: Sunday Roast 😋 
+
+### Celebrations and shout-outs 🎉
+
+Add a note to celebrate the awesome work someone in the community has been doing!
+
+* Solyr grant submitted - led by Tasha Snow (U Maryland) and in collaboration with CryoClud
+* Two new myst releases since last meeting 👀
+*  Ran a standard meeting on scientific content:
+    * [https://articles.continuousfoundation.org/articles/scientific-standards-meeting](https://articles.continuousfoundation.org/articles/scientific-standards-meeting)
+
+### Breakout room and agenda item suggestions
+
+Please add your name to any breakout room topics that you'd like to join.
+
+*Note that this collaboration cafe happened during the inaugural Hub Dash event so there weren't any specific Jupyter Hub topics discussed*
+
+* Prioritization \& Roadmapping
+* Plugins
+* Executable improvements
+* Big bits of work:
+  * Outputs - in progress on getting that over the line (Steve)
+  * [https://github.com/jupyter-book/mystmd/issues/1674](https://github.com/jupyter-book/mystmd/issues/1674)
+  * Outputs
+  * Transformation pipeline
+  * Plugins
+  * JupyterLab MyST
+
+### Notes for Main Room discussion: Prioritization for Jupyter Book
+
+*Thank you for taking notes to allow members of our community to catch up if they weren't able to make the meeting time.*
+
+* Outputs - in progress on getting that over the line (Steve)
+    * [https://github.com/jupyter-book/mystmd/issues/1674](https://github.com/jupyter-book/mystmd/issues/1674)
+* Core health of the project, dev-focused conversations e.g.
+    * [https://github.com/jupyter-book/myst-theme/pull/634](https://github.com/jupyter-book/myst-theme/pull/634)
+    * [https://github.com/jupyter-book/myst-theme/pull/595](https://github.com/jupyter-book/myst-theme/pull/595)
+    * [https://github.com/jupyter-book/myst-spec/pull/67](https://github.com/jupyter-book/myst-spec/pull/67)
+* Plugins, extensibility
+*  Anton:
+    * Mentions lack of development docs on the build pipeline ordering
+    *  Two relevant resources that we may want to update:
+        * [https://mystmd.org/guide/overview#overview-build-process](https://mystmd.org/guide/overview#overview-build-process)
+        * [https://mystmd.org/guide/developer#architecture](https://mystmd.org/guide/developer#architecture)
+* Brigitta: execution tracking issues, are they stale?
+    *  [https://github.com/jupyter-book/mystmd/issues/1026](https://github.com/jupyter-book/mystmd/issues/1026)
+    *  [https://github.com/jupyter-book/mystmd/issues/2019](https://github.com/jupyter-book/mystmd/issues/2019)
+* Big bits of work:
+    * Outputs - in progress on getting that over the line (Steve)
+    * [https://github.com/jupyter-book/mystmd/issues/1674](https://github.com/jupyter-book/mystmd/issues/1674)
+    * Plugins
+    * JupyterLab MyST
+    * Transformation pipeline
+* Stefan is running drop-ins
+    * Tomorrow morning 9am Pacific :)
+*  Action Items:
+    * We can probably get [https://github.com/jupyter-book/mystmd/pull/2413](https://github.com/jupyter-book/mystmd/pull/2413) over the line, I suspect the errors have been fixed in main (pray)
+* How do we get tasks ON the prioritization list, and how do we define them as done?
+    * [https://github.com/orgs/jupyter-book/projects/1](https://github.com/orgs/jupyter-book/projects/1)
+* Talking about the initiative - user story split as a way of refining actionable chunks of work
+* Anton asks about where we open issues for different things (theme vs book)
+* Also touching on Jupyter Book vs mystmd split.
+
 ## 2025-11-18
 
 ### Check-in 💁


### PR DESCRIPTION
Hi folks - we actually didn't have much Jupyter Hub chat at the collaboration cafe on 2 Dec because it was during the hub dash BUT I'm not up to date on documenting the collab cafe notes in the Jupyter Book team compass so it would be super helpful to just merge them here if that's ok?

Feel free to say no - at least I've now got them in git so I can move them in the future too 😅 