### PR TITLE
Fix broken archive links in meetings index

### DIFF
--- a/docs/meetings/index.md
+++ b/docs/meetings/index.md
@@ -38,7 +38,7 @@ collab-cafe/index
 ## Archive of past meeting types
 
 The JupyterHub team used to keep monthly and weekly reports for what they had been up to.
-The notes archives are linked from [weekly-reports](weekly-reports) and [community](community).
+The notes archives are linked from [weekly-reports](weekly-reports/archive) and [community](community/index).
 
 There was also an HPC working group met monthly to discuss JupyterHub deployment on HPC systems and the various software projects supporting those efforts.
-Those notes are linked from [hpc](hpc).
+Those notes are linked from [hpc](hpc/index).


### PR DESCRIPTION
Hyperlinks now point to correct targets.
Closes #890 

_PS: on a fun note, [`lychee`](https://github.com/lycheeverse/lychee) is a link checker I [set up](https://github.com/cocoindex-io/cocoindex/pull/1425) in [another project](https://github.com/cocoindex-io/cocoindex) that tracks stale links & generates a report (based on the interval you set)._