### PR TITLE
Update jobs and recruitment page

### DIFF
--- a/docs/team/jobs/index.md
+++ b/docs/team/jobs/index.md
@@ -4,11 +4,11 @@ This page highlights any open calls we have for funded positions within JupyterH
 
 ## Currently open calls
 
+We don't have any open calls linked at the moment.
+
+## Previous calls
+
 ```{toctree}
 :maxdepth: 1
 JupyterHub and Jupyter Book Community Manager <2026-community-mgr.md>
 ```
-
-## Previous calls
-
-We don't have any previous calls linked from this team compass... yet!


### PR DESCRIPTION
Based on the [announcement on Jupyter's blog](https://blog.jupyter.org/call-for-applications-community-manager-for-jupyterhub-and-jupyter-book-88b128a1a7b9), we passed the deadline for resume and cover letter applications.

@KirstieJane you can press "merge" if you agree with this changes.